### PR TITLE
Allow override of remote Opbeat host.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -36,7 +36,7 @@ var Client = function (options) {
     this.exceptionsAreCritical = 'exceptionsAreCritical' in options ? !!options.exceptionsAreCritical : true;
     this.dsn                   = {
         protocol: 'https', // Opbeat currently only supports HTTPS. Future options might include HTTP and UDP
-        host: options.server || 'opbeat.com',
+        host: options.opbeatApiHostname || 'opbeat.com',
         path: '/api/v1/organizations/' + this.organization_id + '/apps/' + this.app_id + '/errors/'
     };
 


### PR DESCRIPTION
Useful for testing against other environments (e.g. staging etc)
