### PR TITLE
Update dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ metadata fields, most of which are automatlically managed by the
 opbeat node client. But if you wish you can supply some extra details
 using `client_supplied_id`, `extra`, `user` or `query`. If you want to
 know more about all the fields, you should take a look at the full
-[Opbeat API docs](https://opbeat.com/docs/api/errorlog/).
+[Opbeat API docs](http://docs.opbeat.com/api/intake/v1/#error-logging).
 
 To supply any of these extra fields, use the optional options argument
 when calling `opbeat.captureError()`.


### PR DESCRIPTION
I just noticed that some of the links in the README were linking to the old docs so I fixed them :) 

(The new docs look much better and we just shipped the new API docs as well.)
