### PR TITLE
Fixed option.active set by environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,14 @@ var Client = function (options) {
   this.appId             = options.appId || env.OPBEAT_APP_ID;
   this.organizationId    = options.organizationId || env.OPBEAT_ORGANIZATION_ID;
   this.secretToken       = options.secretToken || env.OPBEAT_SECRET_TOKEN;
-  this.active            = ('active' in options ? options.active :
-                             ('OPBEAT_ACTIVE' in env ? env.OPBEAT_ACTIVE :
-                               undefined)) != false;
+
+  this.active = true;
+  if ('active' in options) {
+    if (typeof options.active === 'boolean') this.active = options.active
+    else if (options.active === 'false') this.active = false
+  }
+  else if('OPBEAT_ACTIVE' in env) this.active = env.OPBEAT_ACTIVE !== 'false'
+
   this.logger            = options.logger || require('console-log-level')({ level: clientLogLevel });
   this.hostname          = options.hostname || env.OPBEAT_HOSTNAME || os.hostname();
   this.stackTraceLimit   = 'stackTraceLimit' in options ? options.stackTraceLimit :

--- a/test/client.js
+++ b/test/client.js
@@ -80,7 +80,7 @@ optionFixtures.forEach(function (fixture) {
 
 test('should be configurable by envrionment variable OPBEAT_ACTIVE', function (t) {
   setup();
-  process.env.OPBEAT_ACTIVE = '0';
+  process.env.OPBEAT_ACTIVE = false;
   var client = opbeat({ appId: 'foo', organizationId: 'bar', secretToken: 'baz' });
   t.equal(client.active, false);
   delete process.env.OPBEAT_ACTIVE;
@@ -90,7 +90,7 @@ test('should be configurable by envrionment variable OPBEAT_ACTIVE', function (t
 test('should overwrite OPBEAT_ACTIVE by option property active', function (t) {
   setup();
   var options = { appId: 'foo', organizationId: 'bar', secretToken: 'baz', active: false };
-  process.env.OPBEAT_ACTIVE = '1';
+  process.env.OPBEAT_ACTIVE = true;
   var client = opbeat(options);
   t.equal(client.active, false);
   delete process.env.OPBEAT_ACTIVE;


### PR DESCRIPTION
When setting the active option via environment variable it will always evaluate to `true`.
```js
process.env.test = false
console.log(typeof process.env.test) // 'string'
```
This creates an issue where `this.active` will evaluate to true when comparing to boolean false:
```js
process.env.OPBEAT_ACTIVE = false;
active = ('OPBEAT_ACTIVE' in process.env ? process.env.OPBEAT_ACTIVE : undefined) != false;
console.log(active); // true
```
I've changed the code to take this into account, and I've changed the unit tests to take booleans instead of '0' and '1' as the documentation calls for booleans.