### PR TITLE
Providing a pre-request method that is called before capturing an uncaught exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ var Client = function (options) {
   this.stackTraceLimit = options.stackTraceLimit;
   this.captureExceptions = options.captureExceptions;
   this.exceptionLogLevel = options.exceptionLogLevel;
+  this.prerequestMethod = options.prerequestMethod;
+
   this.api = {
     host: options.apiHost,
     path: '/api/v1/organizations/' + options.organizationId + '/apps/' + options.appId + '/'
@@ -115,6 +117,13 @@ Client.prototype.handleUncaughtExceptions = function (callback) {
   this._uncaughtExceptionListener = function (err) {
     client.logger.debug('Opbeat caught unhandled exception');
 
+    //Collect extra information from the user if they provide a pre request method
+    var extra;
+
+    if(typeof client.prerequestMethod != 'undefined' && client.prerequestMethod != null) {
+      extra = client.prerequestMethod();
+    }
+
     // Since we exit the node-process we cannot guarantee that the
     // listeners will be called, so to ensure a uniform result,
     // we'll remove all event listeners if an uncaught exception is
@@ -129,6 +138,11 @@ Client.prototype.handleUncaughtExceptions = function (callback) {
     var options = {
       level: client.exceptionLogLevel
     };
+
+    if(extra) {
+      options.extra = extra;
+    }
+
     client.captureError(err, options, function (opbeatErr, url) {
       if (opbeatErr) {
         client.logger.info('Could not notify Opbeat!');

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ var OPTS_MATRIX = [
   ['organizationId', 'ORGANIZATION_ID'],
   ['secretToken', 'SECRET_TOKEN'],
   ['active', 'ACTIVE', true],
+  ['prerequestMethod', 'PREREQUEST_METHOD', null],
   ['clientLogLevel', 'CLIENT_LOG_LEVEL', 'info'],
   ['logger', 'LOGGER', function (opts) {
     return require('console-log-level')({ level: opts.clientLogLevel });


### PR DESCRIPTION
This pre-request method will allow users to specify a function of their own to pass back information to opbeat with extra options in the event of an uncaught exception.

This is handy - for our use, we would love to be able to track the extras - as far as the users environment, CLI version, other library versions, etc.

Example usage:

```javascript
var reportExtras = function reportExtras() {
  var ionicInfoMod = require('./ionic/info').IonicTask;
  var ionicInfo = new ionicInfoMod();
  var info = ionicInfo.gatherInfo();
  return info;
}

var opbeat = require('opbeat')({
  organizationId: 'orgId',
  appId: 'appId',
  secretToken: 'token',
  clientLogLevel: 'fatal',
  prerequestMethod: reportExtras
});
```