### PR TITLE
Intermittent test failures in resource starved environments.

### DIFF
--- a/test/instrumentation/index.js
+++ b/test/instrumentation/index.js
@@ -4,7 +4,7 @@ var test = require('tape')
 var mockAgent = require('./_agent')
 
 test('basic', function (t) {
-  var expexted = [
+  var expected = [
     { transaction: 'foo0', signature: 't00', kind: 'type' },
     { transaction: 'foo0', signature: 't01', kind: 'type' },
     { transaction: 'foo0', signature: 'transaction', kind: 'transaction' },
@@ -49,12 +49,12 @@ test('basic', function (t) {
 
     data.traces.groups.forEach(function (trace, index) {
       var trans = 0
-      var rootTrans = expexted[index].signature === 'transaction'
+      var rootTrans = expected[index].signature === 'transaction'
       var parents = rootTrans ? [] : ['transaction']
       if (index > 2) trans++
-      t.equal(trace.transaction, expexted[index].transaction)
-      t.equal(trace.signature, expexted[index].signature)
-      t.equal(trace.kind, expexted[index].kind)
+      t.equal(trace.transaction, expected[index].transaction)
+      t.equal(trace.signature, expected[index].signature)
+      t.equal(trace.kind, expected[index].kind)
       t.equal(trace.timestamp, ts.toISOString())
       t.deepEqual(trace.parents, parents)
       t.ok('_frames' in trace.extra)

--- a/test/instrumentation/trace.js
+++ b/test/instrumentation/trace.js
@@ -38,7 +38,6 @@ test('#duration()', function (t) {
   setTimeout(function () {
     trace.end()
     t.ok(trace.duration() > 49, trace.duration() + ' should be at least 50')
-    t.ok(trace.duration() < 60, trace.duration() + ' should be less than 60')
     t.end()
   }, 50)
 })
@@ -71,7 +70,6 @@ test('#startTime() - root trace', function (t) {
 test('#startTime() - sub trace', function (t) {
   var trans = new Transaction(mockInstrumentation(function () {
     t.ok(trace.startTime() >= 50, trace.startTime() + ' should be at least 50')
-    t.ok(trace.startTime() < 60, trace.startTime() + ' should be less than 60')
     t.end()
   })._agent)
   var trace


### PR DESCRIPTION
There is no guarantee that a tick will run less than 10ms after the specified timeout to `setInterval`. This was causing intermittent failures in resource starved environments.

Also fixed a small typo.