### PR TITLE
Optimize logic around delivery of stack frames

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -147,6 +147,8 @@ function addStackTracesToTraceGroups (groups, traces, cb) {
     var index = trace._groupIndex
     if (~processed.indexOf(index)) return
     processed.push(index)
+    if (!trace._stackObj) return
+
     var done = next()
     traceFrames(trace, function (frames) {
       groups[index].extra._frames = frames.reverse()

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -29,8 +29,8 @@ Trace.prototype.start = function (signature, type) {
 
 Trace.prototype._recordStackTrace = function () {
   var key = this._stacktraceGroupingKey()
-  this._stackObj = stackCache.get(key)
-  if (!this._stackObj) {
+  var stackObj = stackCache.get(key)
+  if (!stackObj) {
     var err = {}
     Error.captureStackTrace(err, this)
     this._stackObj = { err: err }

--- a/test/instrumentation/index.js
+++ b/test/instrumentation/index.js
@@ -57,9 +57,31 @@ test('basic', function (t) {
       t.equal(trace.kind, expected[index].kind)
       t.equal(trace.timestamp, ts.toISOString())
       t.deepEqual(trace.parents, parents)
-      t.ok('_frames' in trace.extra)
-      t.ok(Array.isArray(trace.extra._frames))
     })
+
+    var traceKey = function (trace) {
+      return trace.signature + '|' + trace.parents.join(',')
+    }
+
+    var allKeys = []
+    data.traces.groups.forEach(function (trace, idx) {
+      if (allKeys.indexOf(traceKey(trace)) < 0) {
+        allKeys.push(traceKey(trace))
+      }
+    })
+
+    var keysWithFrames = []
+    data.traces.groups.forEach(function (trace, index) {
+      if ('_frames' in trace.extra) {
+        var key = traceKey(trace)
+        t.ok(Array.isArray(trace.extra._frames))
+        t.notOk(key in keysWithFrames)
+
+        keysWithFrames.push(key)
+      }
+    })
+
+    t.deepEqual(keysWithFrames, allKeys)
 
     t.end()
   })


### PR DESCRIPTION
This will ensure that if we have already sent frames for
a specific trace in the lifetime of the process, we will not
do it again. The server saves frames for traces and only needs
them once.