### PR TITLE
Hapi patch

### DIFF
--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -9,21 +9,40 @@ module.exports = function (hapi, agent) {
   shimmer.wrap(hapi.Server.prototype, 'initialize', function (orig) {
     return function () {
       if (typeof this.ext === 'function') {
-        this.ext('onPreResponse', function (request, reply) {
-          debug('received Hapi onPreResponse event')
+        this.ext('onPreAuth', function (request, reply) {
+          debug('received Hapi onPreAuth event')
 
           if (request.route) {
             var fingerprint = request.route.fingerprint || request.route.path
+
             if (fingerprint) {
               var name = (request.raw && request.raw.req && request.raw.req.method) ||
                          (request.route.method && request.route.method.toUpperCase())
-              if (typeof name === 'string') name = name + ' ' + fingerprint
-              else name = fingerprint
+
+              if (typeof name === 'string') {
+                name = name + ' ' + fingerprint
+              } else {
+                name = fingerprint
+              }
+
               agent._instrumentation.setDefaultTransactionName(name)
             }
           }
 
           return reply.continue()
+        })
+
+        this.ext('onRequest', function (request, reply) {
+          debug('recieved Hapi onRequest event')
+
+          if (request.method === 'options') {
+            var name = (request.raw && request.raw.req && request.raw.req.method) ||
+                       (request.route.method && request.route.method.toUpperCase())
+
+            agent._instrumentation.setDefaultTransactionName(name + ' ' + request.url.pathname)
+          }
+
+          return reply.continue();
         })
       } else {
         debug('unable to enable Hapi instrumentation')


### PR DESCRIPTION
Update hapi instrumentation by making sure to always set the the transaction name, onPreResponse does not get called when the route errors and OPTIONS calles do not follow the same lifecycle

I tested it on hapi 13 but I do not expect it to fail on hapi9+ since it is pretty generic

(fyi if you want I can add some extra stuff that will automatically log errors decently from hapi, something I do manually now)