### PR TITLE
Refactor currentTrace to currentTransaction

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -112,8 +112,8 @@ Agent.prototype.captureError = function (err, data, cb) {
   }
   delete data.request
 
-  var trace = this._instrumentation.currentTrace
-  if (!data.http && trace && trace.transaction.req) data.http = parsers.parseRequest(trace.transaction.req)
+  var trans = this._instrumentation.currentTransaction
+  if (!data.http && trans && trans.req) data.http = parsers.parseRequest(trans.req)
 
   var errUUID = data.extra && data.extra.uuid || uuid.v4()
 

--- a/lib/instrumentation/async-hooks.js
+++ b/lib/instrumentation/async-hooks.js
@@ -9,15 +9,15 @@ module.exports = function (ins) {
   function wrapCallback (original) {
     if (typeof original !== 'function') return original
 
-    var trace = ins.currentTrace
+    var trans = ins.currentTransaction
 
     return instrumented
 
     function instrumented () {
-      var prev = ins.currentTrace
-      ins.currentTrace = trace
+      var prev = ins.currentTransaction
+      ins.currentTransaction = trans
       var result = original.apply(this, arguments)
-      ins.currentTrace = prev
+      ins.currentTransaction = prev
       return result
     }
   }

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -68,35 +68,33 @@ Instrumentation.prototype.startTransaction = function (name, type, result) {
 }
 
 Instrumentation.prototype.endTransaction = function () {
-  var trace = this.currentTrace
-  if (!trace) return debug('cannot end transaction - no active trace found')
-  trace.transaction.end()
+  if (!this.currentTransaction) return debug('cannot end transaction - no active transaction found')
+  this.currentTransaction.end()
 }
 
 Instrumentation.prototype.setDefaultTransactionName = function (name) {
-  var trace = this.currentTrace
-  if (!trace) return debug('no active trace found - cannot set default transaction name')
-  trace.transaction.setDefaultName(name)
+  var trans = this.currentTransaction
+  if (!trans) return debug('no active transaction found - cannot set default transaction name')
+  trans.setDefaultName(name)
 }
 
 Instrumentation.prototype.setTransactionName = function (name) {
-  var trace = this.currentTrace
-  if (!trace) return debug('no active trace found - cannot set transaction name')
-  trace.transaction.name = name
+  var trans = this.currentTransaction
+  if (!trans) return debug('no active transaction found - cannot set transaction name')
+  trans.name = name
 }
 
 Instrumentation.prototype.buildTrace = function () {
-  var transaction = this.currentTrace && this.currentTrace.transaction
-  if (transaction) {
+  if (this.currentTransaction) {
     this._buildTraceFailed = false
-    if (transaction.ended) {
+    if (this.currentTransaction.ended) {
       debug('current transaction already ended - cannot build new trace')
       return null
     }
-    return new Trace(transaction)
+    return new Trace(this.currentTransaction)
   } else {
     this._buildTraceFailed = true
-    debug('no active trace found - cannot build new trace')
+    debug('no active transaction found - cannot build new trace')
     return null
   }
 }

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -11,7 +11,6 @@ function Trace (transaction) {
   this.extra = {}
   this._agent = transaction._agent
   this._parent = transaction._rootTrace
-  this._agent._instrumentation.currentTrace = this
 
   debug('init trace %o', { uuid: this.transaction._uuid })
 }

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -26,6 +26,7 @@ function Transaction (agent, name, type, result) {
   this.ended = false
   this._uuid = uuid.v4()
   this._agent = agent
+  this._agent._instrumentation.currentTransaction = this
 
   debug('start transaction %o', { uuid: this._uuid, name: name, type: type, result: result })
 
@@ -48,18 +49,18 @@ Transaction.prototype.end = function () {
   this._rootTrace.end()
   this.ended = true
 
-  var trace = this._agent._instrumentation.currentTrace
+  var trans = this._agent._instrumentation.currentTransaction
 
   // These two edge-cases should normally not happen, but if the hooks into
   // Node.js doesn't work as intended it might. In that case we want to
   // gracefully handle it. That involves ignoring all traces under the given
   // transaction as they will most likely be incomplete. We still want to send
   // the transaction without any traces to Opbeat as it's still valuable data.
-  if (!trace) {
-    debug('WARNING: no current trace found %o', { current: trace, traces: this.traces.length, uuid: this._uuid })
+  if (!trans) {
+    debug('WARNING: no currentTransaction found %o', { current: trans, traces: this.traces.length, uuid: this._uuid })
     this.traces = []
-  } else if (trace.transaction !== this) {
-    debug('WARNING: transaction is out of sync %o', { traces: this.traces.length, uuid: this._uuid, other: trace.transaction._uuid })
+  } else if (trans !== this) {
+    debug('WARNING: transaction is out of sync %o', { traces: this.traces.length, uuid: this._uuid, other: trans._uuid })
     this.traces = []
   }
 
@@ -73,17 +74,17 @@ Transaction.prototype._recordEndedTrace = function (trace) {
     return
   }
 
-  if (!this._agent._instrumentation.currentTrace) {
+  if (!this._agent._instrumentation.currentTransaction) {
     if (this._agent._instrumentation._buildTraceFailed) {
       // in case the buildTraceFailed boolean is true, we have no way of
       // knowing if traces are missing between the given trace and the
       // traces already pushed to the stack. In that case it's better to bail
-      debug('No current trace available - restore not possible! %o', { uuid: this._uuid })
+      debug('No currentTransaction available - restore not possible! %o', { uuid: this._uuid })
       return
     }
 
-    debug('No current trace available - attempting restore %o', { uuid: this._uuid })
-    this._agent._instrumentation.currentTrace = trace
+    debug('No currentTransaction available - attempting restore %o', { uuid: this._uuid })
+    this._agent._instrumentation.currentTransaction = this
   }
 
   this.traces.push(trace)

--- a/test/instrumentation/index.js
+++ b/test/instrumentation/index.js
@@ -212,7 +212,7 @@ test('stack branching - no parents', function (t) {
   }, 50)
 })
 
-test('currentTrace missing - recoverable', function (t) {
+test('currentTransaction missing - recoverable', function (t) {
   var agent = mockAgent(function (endpoint, data, cb) {
     t.equal(pointerChain(t0), 't0 -> transaction')
 
@@ -229,11 +229,11 @@ test('currentTrace missing - recoverable', function (t) {
   var trans = ins.startTransaction('foo')
   setImmediate(function () {
     t0 = startTrace(ins, 't0')
-    ins.currentTrace = undefined
+    ins.currentTransaction = undefined
     setImmediate(function () {
       t0.end()
       setImmediate(function () {
-        ins.currentTrace = undefined
+        ins.currentTransaction = undefined
         trans.end()
         ins._send()
       })
@@ -241,7 +241,7 @@ test('currentTrace missing - recoverable', function (t) {
   })
 })
 
-test('currentTrace missing - not recoverable', function (t) {
+test('currentTransaction missing - not recoverable', function (t) {
   var agent = mockAgent(function (endpoint, data, cb) {
     t.equal(data.traces.groups.length, 0)
     t.end()
@@ -254,7 +254,7 @@ test('currentTrace missing - not recoverable', function (t) {
     t0 = startTrace(ins, 't0')
     setImmediate(function () {
       t0.end()
-      ins.currentTrace = undefined
+      ins.currentTransaction = undefined
       t1 = startTrace(ins, 't1')
       t.equal(t1, null)
       setImmediate(function () {

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -125,7 +125,7 @@ test('parallel transactions', function (t) {
       t.end()
     }
   })
-  ins.currentTrace = null
+  ins.currentTransaction = null
 
   setImmediate(function () {
     var t1 = new Transaction(ins._agent, 'first')


### PR DESCRIPTION
This PR should technically not change the logic of the Node agent.

Previously we've kept track of a variable called `currentTrace` which pointed to either:

- the latest trace created in the current synchronous code context
- or the value of `currentTrace` at the point in time when the current synchronous code context was queued on the Node.js event loop (if no trace have been created so far in the current synchronous code context)

So far we haven't used `currentTrace` for anything else than getting access to the current transaction (via `currentTrace.transaction`). Having the `currentTrace` gives us more resolution, but is a little trickier to work with. So since we technically don't need this level of details at the moment, this PR refactors the pointer to always point to the current transaction instead (i.e. `currentTrace.transaction === currentTransaction`).