### PR TITLE
Recover lost or wrong transaction

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -21,7 +21,6 @@ module.exports = Instrumentation
 function Instrumentation (agent) {
   this._agent = agent
   this._queue = []
-  this._buildTraceFailed = false
 }
 
 Instrumentation.prototype.start = function () {
@@ -86,17 +85,26 @@ Instrumentation.prototype.setTransactionName = function (name) {
 
 Instrumentation.prototype.buildTrace = function () {
   if (this.currentTransaction) {
-    this._buildTraceFailed = false
     if (this.currentTransaction.ended) {
       debug('current transaction already ended - cannot build new trace')
       return null
     }
     return new Trace(this.currentTransaction)
   } else {
-    this._buildTraceFailed = true
     debug('no active transaction found - cannot build new trace')
     return null
   }
+}
+
+Instrumentation.prototype._recoverTransaction = function (trans) {
+  if (this.currentTransaction === trans) return
+
+  debug('Recovering from wrong currentTransaction %o', {
+    wrong: this.currentTransaction ? this.currentTransaction._uuid : undefined,
+    correct: trans._uuid
+  })
+
+  this.currentTransaction = trans
 }
 
 Instrumentation.prototype._send = function () {

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -49,6 +49,7 @@ Trace.prototype._stacktraceGroupingKey = function () {
 
 Trace.prototype.end = function () {
   this._diff = process.hrtime(this._hrtime)
+  this._agent._instrumentation._recoverTransaction(this.transaction)
   this.ended = true
   debug('ended trace %o', { uuid: this.transaction._uuid, signature: this.signature, type: this.type })
   this.transaction._recordEndedTrace(this)

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -74,18 +74,5 @@ Transaction.prototype._recordEndedTrace = function (trace) {
     return
   }
 
-  if (!this._agent._instrumentation.currentTransaction) {
-    if (this._agent._instrumentation._buildTraceFailed) {
-      // in case the buildTraceFailed boolean is true, we have no way of
-      // knowing if traces are missing between the given trace and the
-      // traces already pushed to the stack. In that case it's better to bail
-      debug('No currentTransaction available - restore not possible! %o', { uuid: this._uuid })
-      return
-    }
-
-    debug('No currentTransaction available - attempting restore %o', { uuid: this._uuid })
-    this._agent._instrumentation.currentTransaction = this
-  }
-
   this.traces.push(trace)
 }


### PR DESCRIPTION
Every time an Trace ends, we now check if the related transaction matches the `currentTransaction` and overwrite it if that's not the case.

This happens a lot with certain database modules, normally if they implement their own connection pooling.

In that case db query callbacks are not queued on the event loop, but added to an internal queue and called once the result comes back from the database. This in turns means that the `currentTransaction` gets set to whatever was the current transaction when the queing logic got initialized - usually during the first request to the Node process.