### PR TITLE
:bug: Avoid throwing when requests are fulfilled before sending data

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,11 @@ var debug = require('debug')('opbeat')
 var trunc = require('unicode-byte-truncate')
 
 var request = function (agent, endpoint, data, cb) {
+   if (!agent._httpClient) {
+    cb(new Error('request fulfilled before data was sent'))
+    return
+  }
+
   agent._httpClient.request(endpoint, data, function (err, res, body) {
     if (err) return cb(err)
     if (res.statusCode < 200 || res.statusCode > 299) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,7 +5,7 @@ var debug = require('debug')('opbeat')
 var trunc = require('unicode-byte-truncate')
 
 var request = function (agent, endpoint, data, cb) {
-   if (!agent._httpClient) {
+  if (!agent._httpClient) {
     cb(new Error('request fulfilled before data was sent'))
     return
   }


### PR DESCRIPTION
This bug can be replicated if you, during a request, start building a trace in a function – but before it is complete, fulfill the request.

**Pseudo code:**
```
function possiblyBackgroundTask() {
    const trace = opbeat.buildTrace();
    trace.start('do something');
    
    new Promise((resolve) => {
        setTimeout(() => {
            trace.end();
        }, 1000);
    });
}

function handleRequest(res) {
    possiblyBackgroundTask();
    res.end('hello');
}
```

**The fatal error I got (crashing the app):**
```
node_modules/opbeat/lib/request.js:8
  agent._httpClient.request(endpoint, data, function (err, res, body) {
                   ^

TypeError: Cannot read property 'request' of undefined
    at request (node_modules/opbeat/lib/request.js:8:20)
    at Object.exports.transactions (node_modules/opbeat/lib/request.js:37:3)
    at Instrumentation.<anonymous> (node_modules/opbeat/lib/instrumentation/index.js:132:13)
    at node_modules/opbeat/lib/instrumentation/index.js:152:5
    at f (node_modules/once/once.js:17:25)
    at node_modules/after-all/index.js:35:11
    at nextTickCallbackWith0Args (node.js:433:9)
    at process._tickCallback (node.js:362:13)
```