### PR TITLE
Add mysql support

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,0 +1,3 @@
+mysql:
+  versions: ^2.0.0
+  commands: tape test/instrumentation/modules/mysql.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: node_js
+services:
+- mysql
 node_js:
 - '6'
 - '5'

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -56,8 +56,8 @@ Agent.prototype._init = function (opts) {
   this.exceptionLogLevel = opts.exceptionLogLevel
   this.instrument = opts.instrument
   this.filter = opts.filter
+  this.ff_captureFrame = opts.ff_captureFrame
   this._apiHost = opts._apiHost
-  this._ff_captureFrame = opts._ff_captureFrame
 }
 
 Agent.prototype.start = function (opts) {
@@ -123,7 +123,7 @@ Agent.prototype.captureError = function (err, data, cb) {
     parsers.parseMessage(err, data)
     logger.error(data.message, { uuid: errUUID })
     err = new Error(data.message)
-  } else if (this._ff_captureFrame && !err.uncaught) {
+  } else if (this.ff_captureFrame && !err.uncaught) {
     var captureFrameError = new Error()
   }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -57,6 +57,7 @@ Agent.prototype._init = function (opts) {
   this.instrument = opts.instrument
   this.filter = opts.filter
   this.ff_captureFrame = opts.ff_captureFrame
+  this.ff_mysql = opts.ff_mysql
   this._apiHost = opts._apiHost
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,14 +14,15 @@ var OPTS_MATRIX = [
   ['exceptionLogLevel', 'EXCEPTION_LOG_LEVEL', 'fatal'],
   ['instrument', 'INSTRUMENT', true],
   ['filter'],
-  ['_ff_captureFrame', 'FF_CAPTURE_FRAME', false]
+  ['ff_captureFrame', 'FF_CAPTURE_FRAME', false],
+  ['ff_mysql', 'FF_MYSQL', false]
 ]
 
 var BOOL_OPTS = [
   'active',
   'captureExceptions',
   'instrument',
-  '_ff_captureFrame'
+  'ff_captureFrame'
 ]
 
 var normalizeBool = function (bool) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,7 +22,8 @@ var BOOL_OPTS = [
   'active',
   'captureExceptions',
   'instrument',
-  'ff_captureFrame'
+  'ff_captureFrame',
+  'ff_mysql'
 ]
 
 var normalizeBool = function (bool) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -11,7 +11,7 @@ var debug = require('debug')('opbeat')
 var parsers = require('../parsers')
 var request = require('../request')
 
-var MODULES = ['http', 'https', 'generic-pool', 'mongodb-core', 'pg', 'express', 'hapi']
+var MODULES = ['http', 'https', 'generic-pool', 'mongodb-core', 'pg', 'mysql', 'express', 'hapi']
 var MAX_QUEUE_SIZE = Infinity
 var MAX_SEND_DELAY = 60000
 var MAX_SEND_DELAY_ON_BOOT = 5000

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -11,7 +11,7 @@ var debug = require('debug')('opbeat')
 var parsers = require('../parsers')
 var request = require('../request')
 
-var MODULES = ['http', 'https', 'generic-pool', 'mongodb-core', 'pg', 'mysql', 'express', 'hapi']
+var MODULES = ['http', 'https', 'generic-pool', 'mongodb-core', 'pg', 'express', 'hapi']
 var MAX_QUEUE_SIZE = Infinity
 var MAX_SEND_DELAY = 60000
 var MAX_SEND_DELAY_ON_BOOT = 5000
@@ -27,6 +27,7 @@ function Instrumentation (agent) {
 
 Instrumentation.prototype.start = function () {
   if (!this._agent.instrument) return
+  if (this._agent.ff_mysql) MODULES.push('mysql')
 
   require('./async-hooks')(this)
 

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -25,7 +25,9 @@ module.exports = function (mysql, opbeat, version) {
   function wrapCreateConnection (original) {
     return function wrappedCreateConnection () {
       var connection = original.apply(this, arguments)
+
       wrapQueryable(connection, 'connection', opbeat)
+
       return connection
     }
   }

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -114,7 +114,7 @@ function wrapQueryable (obj, objType, opbeat) {
         }
 
         if (sqlStr) {
-          debug('extracted sql from mysql query', { uuid: uuid, sql: sqlStr })
+          debug('extracted sql from mysql query %o', { uuid: uuid, sql: sqlStr })
           trace.extra.sql = sqlStr
           trace.signature = sqlSummary(sqlStr)
         }

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -14,18 +14,47 @@ module.exports = function (mysql, opbeat, version) {
   debug('shimming mysql.createConnection')
   shimmer.wrap(mysql, 'createConnection', wrapCreateConnection)
 
+  debug('shimming mysql.createPool')
+  shimmer.wrap(mysql, 'createPool', wrapCreatePool)
+
   return mysql
 
   function wrapCreateConnection (original) {
     return function wrappedCreateConnection () {
       var connection = original.apply(this, arguments)
-      wrapObj(connection, 'connection', opbeat)
+      wrapQueryable(connection, 'connection', opbeat)
       return connection
+    }
+  }
+
+  function wrapCreatePool (original) {
+    return function wrappedCreatePool () {
+      var pool = original.apply(this, arguments)
+
+      debug('shimming mysql pool.getConnection')
+      shimmer.wrap(pool, 'getConnection', wrapGetConnection)
+
+      return pool
+    }
+  }
+
+  function wrapGetConnection (original) {
+    return function wrappedGetConnection () {
+      var cb = arguments[0]
+
+      if (typeof cb === 'function') {
+        arguments[0] = function wrapedCallback (err, connection) { // eslint-disable-line handle-callback-err
+          if (connection) wrapQueryable(connection, 'getConnection() > connection', opbeat)
+          return cb.apply(this, arguments)
+        }
+      }
+
+      return original.apply(this, arguments)
     }
   }
 }
 
-function wrapObj (obj, objType, opbeat) {
+function wrapQueryable (obj, objType, opbeat) {
   debug('shimming mysql %s.query', objType)
   shimmer.wrap(obj, 'query', wrapQuery)
 
@@ -33,6 +62,7 @@ function wrapObj (obj, objType, opbeat) {
     return function wrappedQuery (sql, values, cb) {
       var trace = opbeat.buildTrace()
       var uuid = trace && trace.transaction._uuid
+      var hasCallback = false
       var sqlStr
 
       debug('intercepted call to mysql %s.query %o', objType, { uuid: uuid })
@@ -70,10 +100,10 @@ function wrapObj (obj, objType, opbeat) {
 
       var result = original.apply(this, arguments)
 
-      if (trace && result) {
+      if (trace && result && !hasCallback) {
         shimmer.wrap(result, 'emit', function (original) {
           return function (event) {
-            if (!trace.started) trace.start()
+            trace.start()
             switch (event) {
               case 'error':
               case 'end':
@@ -87,6 +117,7 @@ function wrapObj (obj, objType, opbeat) {
       return result
 
       function wrapCallback (cb) {
+        hasCallback = true
         trace.start()
         return function wrappedCallback () {
           trace.end()

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -1,0 +1,98 @@
+'use strict'
+
+var shimmer = require('shimmer')
+var semver = require('semver')
+var sqlSummary = require('sql-summary')
+var debug = require('debug')('opbeat')
+
+module.exports = function (mysql, opbeat, version) {
+  if (!semver.satisfies(version, '^2.0.0')) {
+    debug('mysql version %s not suppoted - aborting...', version)
+    return mysql
+  }
+
+  debug('shimming mysql.createConnection')
+  shimmer.wrap(mysql, 'createConnection', wrapCreateConnection)
+
+  return mysql
+
+  function wrapCreateConnection (original) {
+    return function wrappedCreateConnection () {
+      var connection = original.apply(this, arguments)
+      wrapObj(connection, 'connection', opbeat)
+      return connection
+    }
+  }
+}
+
+function wrapObj (obj, objType, opbeat) {
+  debug('shimming mysql %s.query', objType)
+  shimmer.wrap(obj, 'query', wrapQuery)
+
+  function wrapQuery (original) {
+    return function wrappedQuery (sql, values, cb) {
+      var trace = opbeat.buildTrace()
+      var uuid = trace && trace.transaction._uuid
+      var sqlStr
+
+      debug('intercepted call to mysql %s.query %o', objType, { uuid: uuid })
+
+      if (trace) {
+        trace.type = 'db.mysql.query'
+
+        switch (typeof sql) {
+          case 'string':
+            sqlStr = sql
+            break
+          case 'object':
+            if (typeof sql._callback === 'function') {
+              sql._callback = wrapCallback(sql._callback)
+            }
+            sqlStr = sql.sql
+            break
+          case 'function':
+            arguments[0] = wrapCallback(sql)
+            break
+        }
+
+        if (sqlStr) {
+          debug('extracted sql from mysql query', { uuid: uuid, sql: sqlStr })
+          trace.extra.sql = sqlStr
+          trace.signature = sqlSummary(sqlStr)
+        }
+
+        if (typeof values === 'function') {
+          arguments[1] = wrapCallback(values)
+        } else if (typeof cb === 'function') {
+          arguments[2] = wrapCallback(cb)
+        }
+      }
+
+      var result = original.apply(this, arguments)
+
+      if (trace && result) {
+        shimmer.wrap(result, 'emit', function (original) {
+          return function (event) {
+            if (!trace.started) trace.start()
+            switch (event) {
+              case 'error':
+              case 'end':
+                trace.end()
+            }
+            return original.apply(this, arguments)
+          }
+        })
+      }
+
+      return result
+
+      function wrapCallback (cb) {
+        trace.start()
+        return function wrappedCallback () {
+          trace.end()
+          return cb.apply(this, arguments)
+        }
+      }
+    }
+  }
+}

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -17,6 +17,9 @@ module.exports = function (mysql, opbeat, version) {
   debug('shimming mysql.createPool')
   shimmer.wrap(mysql, 'createPool', wrapCreatePool)
 
+  debug('shimming mysql.createPoolCluster')
+  shimmer.wrap(mysql, 'createPoolCluster', wrapCreatePoolCluster)
+
   return mysql
 
   function wrapCreateConnection (original) {
@@ -35,6 +38,29 @@ module.exports = function (mysql, opbeat, version) {
       shimmer.wrap(pool, 'getConnection', wrapGetConnection)
 
       return pool
+    }
+  }
+
+  function wrapCreatePoolCluster (original) {
+    return function wrappedCreatePoolCluster () {
+      var cluster = original.apply(this, arguments)
+
+      debug('shimming mysql cluster.of')
+      shimmer.wrap(cluster, 'of', function wrapOf (original) {
+        return function wrappedOf () {
+          var ofCluster = original.apply(this, arguments)
+
+          debug('shimming mysql cluster of.getConnection')
+          shimmer.wrap(ofCluster, 'getConnection', wrapGetConnection)
+
+          return ofCluster
+        }
+      })
+
+      debug('shimming mysql cluster.getConnection')
+      shimmer.wrap(cluster, 'getConnection', wrapGetConnection)
+
+      return cluster
     }
   }
 

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -23,7 +23,10 @@ function Trace (transaction) {
 }
 
 Trace.prototype.start = function (signature, type) {
-  if (this.started) return
+  if (this.started) {
+    debug('tried to start already started trace - ignoring %o', { uuid: this.transaction._uuid, signature: this.signature || signature, type: this.type || type })
+    return
+  }
 
   this.started = true
   this.signature = signature || this.signature

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -61,6 +61,10 @@ Trace.prototype._stacktraceGroupingKey = function () {
 }
 
 Trace.prototype.end = function () {
+  if (this.ended) {
+    debug('tried to end already ended trace - ignoring %o', { uuid: this.transaction._uuid, signature: this.signature, type: this.type })
+    return
+  }
   this._diff = process.hrtime(this._hrtime)
   this._agent._instrumentation._recoverTransaction(this.transaction)
   this.ended = true

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -7,6 +7,7 @@ module.exports = Trace
 
 function Trace (transaction) {
   this.transaction = transaction
+  this.started = false
   this.ended = false
   this.extra = {}
   this.signature = null
@@ -22,8 +23,11 @@ function Trace (transaction) {
 }
 
 Trace.prototype.start = function (signature, type) {
-  this.signature = signature
-  this.type = type || 'custom.code'
+  if (this.started) return
+
+  this.started = true
+  this.signature = signature || this.signature
+  this.type = type || this.type || 'custom.code'
 
   this._recordStackTrace()
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The official Opbeat agent for Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tape test/*.js test/instrumentation/**/*.js",
+    "test": "standard && tape test/*.js test/instrumentation/**/*.js && tav",
     "test-cli": "node test/scripts/cli.js"
   },
   "directories": {
@@ -48,7 +48,7 @@
     "node-uuid": "^1.4.7",
     "opbeat-http-client": "^1.0.3",
     "opbeat-release-tracker": "^1.1.1",
-    "require-in-the-middle": "^2.1.0",
+    "require-in-the-middle": "^2.1.2",
     "semver": "^5.1.0",
     "shimmer": "^1.1.0",
     "sql-summary": "^1.0.0",
@@ -65,6 +65,7 @@
     "restify": "^4.0.4",
     "standard": "^6.0.8",
     "tape": "^4.5.1",
+    "test-all-versions": "^1.1.2",
     "untildify": "^2.0.0"
   },
   "coordinates": [

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "express": "^4.13.4",
     "inquirer": "^0.12.0",
     "mkdirp": "^0.5.0",
+    "mysql": "^2.11.1",
     "nock": "^8.0.0",
     "restify": "^4.0.4",
     "standard": "^6.0.8",

--- a/test/agent.js
+++ b/test/agent.js
@@ -27,7 +27,8 @@ var optionFixtures = [
   ['exceptionLogLevel', 'EXCEPTION_LOG_LEVEL', 'fatal'],
   ['instrument', 'INSTRUMENT', true],
   ['filter'],
-  ['ff_captureFrame', 'FF_CAPTURE_FRAME', false]
+  ['ff_captureFrame', 'FF_CAPTURE_FRAME', false],
+  ['ff_mysql', 'FF_MYSQL', false]
 ]
 
 var falsyValues = [false, 0, '', '0', 'false', 'no', 'off', 'disabled']

--- a/test/agent.js
+++ b/test/agent.js
@@ -27,7 +27,7 @@ var optionFixtures = [
   ['exceptionLogLevel', 'EXCEPTION_LOG_LEVEL', 'fatal'],
   ['instrument', 'INSTRUMENT', true],
   ['filter'],
-  ['_ff_captureFrame', 'FF_CAPTURE_FRAME', false]
+  ['ff_captureFrame', 'FF_CAPTURE_FRAME', false]
 ]
 
 var falsyValues = [false, 0, '', '0', 'false', 'no', 'off', 'disabled']

--- a/test/instrumentation/modules/mysql.js
+++ b/test/instrumentation/modules/mysql.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var agent = require('opbeat').start({
+var agent = require('../../..').start({
   appId: 'test',
   organizationId: 'test',
   secretToken: 'test',

--- a/test/instrumentation/modules/mysql.js
+++ b/test/instrumentation/modules/mysql.js
@@ -170,6 +170,22 @@ test('mysql.createConnection', function (t) {
         basicQueryStream(stream, t, trans)
       })
     })
+
+    t.test('do not consume stream', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      var sql = 'SELECT 1 + 1 AS solution'
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        connection.query(sql)
+        setTimeout(function () {
+          trans.end()
+          agent._instrumentation._send()
+        }, 100)
+      })
+    })
   })
 })
 

--- a/test/instrumentation/modules/mysql.js
+++ b/test/instrumentation/modules/mysql.js
@@ -4,7 +4,8 @@ var agent = require('../../..').start({
   appId: 'test',
   organizationId: 'test',
   secretToken: 'test',
-  captureExceptions: false
+  captureExceptions: false,
+  ff_mysql: true
 })
 
 var test = require('tape')

--- a/test/instrumentation/modules/mysql.js
+++ b/test/instrumentation/modules/mysql.js
@@ -8,7 +8,7 @@ var agent = require('../../..').start({
 })
 
 var test = require('tape')
-var execSync = require('child_process').execSync
+var exec = require('child_process').exec
 var mysql = require('mysql')
 
 var connection
@@ -20,10 +20,11 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + 1 AS solution'
-      var trans = agent.startTransaction('foo')
-      connection.query(sql, basicQueryCallback(t, trans))
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        connection.query(sql, basicQueryCallback(t, trans))
+      })
     })
 
     t.test('connection.query(sql, values, callback)', function (t) {
@@ -31,10 +32,11 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + ? AS solution'
-      var trans = agent.startTransaction('foo')
-      connection.query(sql, [1], basicQueryCallback(t, trans))
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        connection.query(sql, [1], basicQueryCallback(t, trans))
+      })
     })
 
     t.test('connection.query(options, callback)', function (t) {
@@ -42,10 +44,11 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + 1 AS solution'
-      var trans = agent.startTransaction('foo')
-      connection.query({ sql: sql }, basicQueryCallback(t, trans))
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        connection.query({ sql: sql }, basicQueryCallback(t, trans))
+      })
     })
 
     t.test('connection.query(options, values, callback)', function (t) {
@@ -53,10 +56,11 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + ? AS solution'
-      var trans = agent.startTransaction('foo')
-      connection.query({ sql: sql }, [1], basicQueryCallback(t, trans))
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        connection.query({ sql: sql }, [1], basicQueryCallback(t, trans))
+      })
     })
 
     t.test('connection.query(query)', function (t) {
@@ -64,11 +68,12 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + 1 AS solution'
-      var trans = agent.startTransaction('foo')
-      var query = mysql.createQuery(sql, basicQueryCallback(t, trans))
-      connection.query(query)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var query = mysql.createQuery(sql, basicQueryCallback(t, trans))
+        connection.query(query)
+      })
     })
 
     t.test('connection.query(query_with_values)', function (t) {
@@ -76,11 +81,12 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + ? AS solution'
-      var trans = agent.startTransaction('foo')
-      var query = mysql.createQuery(sql, [1], basicQueryCallback(t, trans))
-      connection.query(query)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var query = mysql.createQuery(sql, [1], basicQueryCallback(t, trans))
+        connection.query(query)
+      })
     })
   })
 
@@ -90,11 +96,12 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + 1 AS solution'
-      var trans = agent.startTransaction('foo')
-      var stream = connection.query(sql)
-      basicQueryStream(stream, t, trans)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var stream = connection.query(sql)
+        basicQueryStream(stream, t, trans)
+      })
     })
 
     t.test('connection.query(sql, values)', function (t) {
@@ -102,11 +109,12 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + ? AS solution'
-      var trans = agent.startTransaction('foo')
-      var stream = connection.query(sql, [1])
-      basicQueryStream(stream, t, trans)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var stream = connection.query(sql, [1])
+        basicQueryStream(stream, t, trans)
+      })
     })
 
     t.test('connection.query(options)', function (t) {
@@ -114,11 +122,12 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + 1 AS solution'
-      var trans = agent.startTransaction('foo')
-      var stream = connection.query({ sql: sql })
-      basicQueryStream(stream, t, trans)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var stream = connection.query({ sql: sql })
+        basicQueryStream(stream, t, trans)
+      })
     })
 
     t.test('connection.query(options, values)', function (t) {
@@ -126,11 +135,12 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + ? AS solution'
-      var trans = agent.startTransaction('foo')
-      var stream = connection.query({ sql: sql }, [1])
-      basicQueryStream(stream, t, trans)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var stream = connection.query({ sql: sql }, [1])
+        basicQueryStream(stream, t, trans)
+      })
     })
 
     t.test('connection.query(query)', function (t) {
@@ -138,12 +148,13 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + 1 AS solution'
-      var trans = agent.startTransaction('foo')
-      var query = mysql.createQuery(sql)
-      var stream = connection.query(query)
-      basicQueryStream(stream, t, trans)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var query = mysql.createQuery(sql)
+        var stream = connection.query(query)
+        basicQueryStream(stream, t, trans)
+      })
     })
 
     t.test('connection.query(query_with_values)', function (t) {
@@ -151,12 +162,13 @@ test('mysql.createConnection', function (t) {
         assertBasicQuery(t, sql, data)
         t.end()
       })
-      setup()
       var sql = 'SELECT 1 + ? AS solution'
-      var trans = agent.startTransaction('foo')
-      var query = mysql.createQuery(sql, [1])
-      var stream = connection.query(query)
-      basicQueryStream(stream, t, trans)
+      setup(function () {
+        var trans = agent.startTransaction('foo')
+        var query = mysql.createQuery(sql, [1])
+        var stream = connection.query(query)
+        basicQueryStream(stream, t, trans)
+      })
     })
   })
 })
@@ -204,14 +216,17 @@ function assertBasicQuery (t, sql, data) {
   t.equal(data.transactions[0].transaction, 'foo')
 }
 
-function setup () {
+function setup (cb) {
   teardown() // just in case it didn't happen at the end of the previous test
-  execSync('mysql -u root < mysql_reset.sql', { cwd: __dirname })
-  connection = mysql.createConnection({
-    user: 'root',
-    database: 'test_opbeat'
+  exec('mysql -u root < mysql_reset.sql', { cwd: __dirname }, function (err) {
+    if (err) throw err
+    connection = mysql.createConnection({
+      user: 'root',
+      database: 'test_opbeat'
+    })
+    connection.connect()
+    cb()
   })
-  connection.connect()
 }
 
 function teardown () {

--- a/test/instrumentation/modules/mysql.js
+++ b/test/instrumentation/modules/mysql.js
@@ -1,0 +1,236 @@
+'use strict'
+
+var agent = require('opbeat').start({
+  appId: 'test',
+  organizationId: 'test',
+  secretToken: 'test',
+  captureExceptions: false
+})
+
+var test = require('tape')
+var execSync = require('child_process').execSync
+var mysql = require('mysql')
+
+var connection
+
+test('mysql.createConnection', function (t) {
+  t.test('basic query with callback', function (t) {
+    t.test('connection.query(sql, callback)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + 1 AS solution'
+      var trans = agent.startTransaction('foo')
+      connection.query(sql, basicQueryCallback(t, trans))
+    })
+
+    t.test('connection.query(sql, values, callback)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + ? AS solution'
+      var trans = agent.startTransaction('foo')
+      connection.query(sql, [1], basicQueryCallback(t, trans))
+    })
+
+    t.test('connection.query(options, callback)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + 1 AS solution'
+      var trans = agent.startTransaction('foo')
+      connection.query({ sql: sql }, basicQueryCallback(t, trans))
+    })
+
+    t.test('connection.query(options, values, callback)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + ? AS solution'
+      var trans = agent.startTransaction('foo')
+      connection.query({ sql: sql }, [1], basicQueryCallback(t, trans))
+    })
+
+    t.test('connection.query(query)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + 1 AS solution'
+      var trans = agent.startTransaction('foo')
+      var query = mysql.createQuery(sql, basicQueryCallback(t, trans))
+      connection.query(query)
+    })
+
+    t.test('connection.query(query_with_values)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + ? AS solution'
+      var trans = agent.startTransaction('foo')
+      var query = mysql.createQuery(sql, [1], basicQueryCallback(t, trans))
+      connection.query(query)
+    })
+  })
+
+  t.test('basic query streaming', function (t) {
+    t.test('connection.query(sql)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + 1 AS solution'
+      var trans = agent.startTransaction('foo')
+      var stream = connection.query(sql)
+      basicQueryStream(stream, t, trans)
+    })
+
+    t.test('connection.query(sql, values)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + ? AS solution'
+      var trans = agent.startTransaction('foo')
+      var stream = connection.query(sql, [1])
+      basicQueryStream(stream, t, trans)
+    })
+
+    t.test('connection.query(options)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + 1 AS solution'
+      var trans = agent.startTransaction('foo')
+      var stream = connection.query({ sql: sql })
+      basicQueryStream(stream, t, trans)
+    })
+
+    t.test('connection.query(options, values)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + ? AS solution'
+      var trans = agent.startTransaction('foo')
+      var stream = connection.query({ sql: sql }, [1])
+      basicQueryStream(stream, t, trans)
+    })
+
+    t.test('connection.query(query)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + 1 AS solution'
+      var trans = agent.startTransaction('foo')
+      var query = mysql.createQuery(sql)
+      var stream = connection.query(query)
+      basicQueryStream(stream, t, trans)
+    })
+
+    t.test('connection.query(query_with_values)', function (t) {
+      resetAgent(function (endpoint, data, cb) {
+        assertBasicQuery(t, sql, data)
+        t.end()
+      })
+      setup()
+      var sql = 'SELECT 1 + ? AS solution'
+      var trans = agent.startTransaction('foo')
+      var query = mysql.createQuery(sql, [1])
+      var stream = connection.query(query)
+      basicQueryStream(stream, t, trans)
+    })
+  })
+})
+
+function basicQueryCallback (t, trans) {
+  return function (err, rows, fields) {
+    t.error(err)
+    t.equal(rows[0].solution, 2)
+    trans.end()
+    agent._instrumentation._send()
+  }
+}
+
+function basicQueryStream (stream, t, trans) {
+  var results = 0
+  stream.on('error', function (err) {
+    t.error(err)
+  })
+  stream.on('result', function (row) {
+    results++
+    t.equal(row.solution, 2)
+  })
+  stream.on('end', function () {
+    t.equal(results, 1)
+    trans.end()
+    agent._instrumentation._send()
+  })
+}
+
+function assertBasicQuery (t, sql, data) {
+  t.equal(data.traces.groups.length, 2)
+
+  t.equal(data.traces.groups[0].extra.sql, sql)
+  t.equal(data.traces.groups[0].kind, 'db.mysql.query')
+  t.deepEqual(data.traces.groups[0].parents, ['transaction'])
+  t.equal(data.traces.groups[0].signature, 'SELECT')
+  t.equal(data.traces.groups[0].transaction, 'foo')
+
+  t.equal(data.traces.groups[1].kind, 'transaction')
+  t.deepEqual(data.traces.groups[1].parents, [])
+  t.equal(data.traces.groups[1].signature, 'transaction')
+  t.equal(data.traces.groups[1].transaction, 'foo')
+
+  t.equal(data.transactions.length, 1)
+  t.equal(data.transactions[0].transaction, 'foo')
+}
+
+function setup () {
+  teardown() // just in case it didn't happen at the end of the previous test
+  execSync('mysql -u root < mysql_reset.sql', { cwd: __dirname })
+  connection = mysql.createConnection({
+    user: 'root',
+    database: 'test_opbeat'
+  })
+  connection.connect()
+}
+
+function teardown () {
+  if (connection) {
+    connection.end()
+    connection = undefined
+  }
+}
+
+function resetAgent (cb) {
+  agent._httpClient = { request: function () {
+    teardown()
+    cb.apply(this, arguments)
+  } }
+
+  var ins = agent._instrumentation
+  if (ins._timeout) {
+    clearTimeout(ins._timeout)
+    ins._timeout = null
+  }
+  ins._queue = []
+}

--- a/test/instrumentation/modules/mysql.js
+++ b/test/instrumentation/modules/mysql.js
@@ -17,7 +17,9 @@ var queryable
 var factories = [
   [createConnection, 'connection'],
   [createPool, 'pool'],
-  [createPoolAndGetConnection, 'pool > connection']
+  [createPoolAndGetConnection, 'pool > connection'],
+  [createPoolClusterAndGetConnection, 'poolCluster > connection'],
+  [createPoolClusterAndGetConnectionViaOf, 'poolCluster > of > connection']
 ]
 
 factories.forEach(function (f) {
@@ -310,6 +312,47 @@ function createPoolAndGetConnection (cb) {
       database: 'test_opbeat'
     })
     pool.getConnection(function (err, conn) {
+      if (err) throw err
+      queryable = conn
+      cb()
+    })
+  })
+}
+
+function createPoolClusterAndGetConnection (cb) {
+  setup(function () {
+    teardown = function teardown () {
+      if (cluster) {
+        cluster.end()
+        cluster = undefined
+      }
+    }
+
+    var cluster = mysql.createPoolCluster()
+    cluster.add({
+      user: 'root',
+      database: 'test_opbeat'
+    })
+    cluster.getConnection(function (err, conn) {
+      if (err) throw err
+      queryable = conn
+      cb()
+    })
+  })
+}
+
+function createPoolClusterAndGetConnectionViaOf (cb) {
+  setup(function () {
+    teardown = function teardown () {
+      cluster.end()
+    }
+
+    var cluster = mysql.createPoolCluster()
+    cluster.add({
+      user: 'root',
+      database: 'test_opbeat'
+    })
+    cluster.of('*').getConnection(function (err, conn) {
       if (err) throw err
       queryable = conn
       cb()

--- a/test/instrumentation/modules/mysql.js
+++ b/test/instrumentation/modules/mysql.js
@@ -214,6 +214,8 @@ function assertBasicQuery (t, sql, data) {
 
   t.equal(data.transactions.length, 1)
   t.equal(data.transactions[0].transaction, 'foo')
+  t.equal(data.transactions[0].durations.length, 1)
+  t.ok(data.transactions[0].durations[0] > 0)
 }
 
 function setup (cb) {

--- a/test/instrumentation/modules/mysql_reset.sql
+++ b/test/instrumentation/modules/mysql_reset.sql
@@ -1,0 +1,2 @@
+DROP DATABASE IF EXISTS test_opbeat;
+CREATE DATABASE test_opbeat;


### PR DESCRIPTION
Add support for tracing of mysql queries

- [x] trace queries made on `mysql.createConnection`
- [x] trace queries made on `mysql.createPool`
- [x] trace queries made on `mysql.createPoolCluster`
- [x] complete tests
- [x] Add mysql feature flag

To use this feature use the property `ff_mysql: true` when calling `start()` or set environment variable `OPBEAT_FF_MYSQL=on`