### PR TITLE
Capture transactions whos HTTP request have timed out

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -55,6 +55,7 @@ Agent.prototype._init = function (opts) {
   this.captureExceptions = opts.captureExceptions
   this.exceptionLogLevel = opts.exceptionLogLevel
   this.timeout = {
+    active: opts.timeout,
     errorResult: opts.timeoutErrorResult,
     errorThreshold: opts.timeoutErrorResult,
     socketClosedDelay: opts.timeoutSocketClosedDelay

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -54,6 +54,11 @@ Agent.prototype._init = function (opts) {
   this.stackTraceLimit = opts.stackTraceLimit
   this.captureExceptions = opts.captureExceptions
   this.exceptionLogLevel = opts.exceptionLogLevel
+  this.timeout = {
+    errorResult: opts.timeoutErrorResult,
+    errorThreshold: opts.timeoutErrorResult,
+    socketClosedDelay: opts.timeoutSocketClosedDelay
+  }
   this.instrument = opts.instrument
   this.filter = opts.filter
   this.ff_captureFrame = opts.ff_captureFrame

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -57,8 +57,7 @@ Agent.prototype._init = function (opts) {
   this.timeout = {
     active: opts.timeout,
     errorResult: opts.timeoutErrorResult,
-    errorThreshold: opts.timeoutErrorResult,
-    socketClosedDelay: opts.timeoutSocketClosedDelay
+    errorThreshold: opts.timeoutErrorThreshold
   }
   this.instrument = opts.instrument
   this.filter = opts.filter

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,7 +15,6 @@ var OPTS_MATRIX = [
   ['timeout', 'TIMEOUT', true],
   ['timeoutErrorResult', 'TIMEOUT_ERROR_RESULT', 503],
   ['timeoutErrorThreshold', 'TIMEOUT_ERROR_THRESHOLD', 25000],
-  ['timeoutSocketClosedDelay', 'TIMEOUT_SOCKET_CLOSED_DELAY', 120000],
   ['instrument', 'INSTRUMENT', true],
   ['filter'],
   ['ff_captureFrame', 'FF_CAPTURE_FRAME', false]

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@ var OPTS_MATRIX = [
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],
   ['exceptionLogLevel', 'EXCEPTION_LOG_LEVEL', 'fatal'],
   ['timeout', 'TIMEOUT', true],
-  ['timeoutErrorResult', 'TIMEOUT_ERROR_RESULT', 500],
+  ['timeoutErrorResult', 'TIMEOUT_ERROR_RESULT', 503],
   ['timeoutErrorThreshold', 'TIMEOUT_ERROR_THRESHOLD', 25000],
   ['timeoutSocketClosedDelay', 'TIMEOUT_SOCKET_CLOSED_DELAY', 120000],
   ['instrument', 'INSTRUMENT', true],

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ var OPTS_MATRIX = [
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', Infinity],
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],
   ['exceptionLogLevel', 'EXCEPTION_LOG_LEVEL', 'fatal'],
+  ['timeout', 'TIMEOUT', true],
   ['timeoutErrorResult', 'TIMEOUT_ERROR_RESULT', 500],
   ['timeoutErrorThreshold', 'TIMEOUT_ERROR_THRESHOLD', 25000],
   ['timeoutSocketClosedDelay', 'TIMEOUT_SOCKET_CLOSED_DELAY', 120000],
@@ -23,6 +24,7 @@ var OPTS_MATRIX = [
 var BOOL_OPTS = [
   'active',
   'captureExceptions',
+  'timeout',
   'instrument',
   'ff_captureFrame'
 ]

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,9 @@ var OPTS_MATRIX = [
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', Infinity],
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],
   ['exceptionLogLevel', 'EXCEPTION_LOG_LEVEL', 'fatal'],
+  ['timeoutErrorResult', 'TIMEOUT_ERROR_RESULT', 500],
+  ['timeoutErrorThreshold', 'TIMEOUT_ERROR_THRESHOLD', 25000],
+  ['timeoutSocketClosedDelay', 'TIMEOUT_SOCKET_CLOSED_DELAY', 120000],
   ['instrument', 'INSTRUMENT', true],
   ['filter'],
   ['ff_captureFrame', 'FF_CAPTURE_FRAME', false]

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -14,8 +14,7 @@ exports.instrumentRequest = function (agent, moduleName) {
       if (event === 'request') {
         debug('intercepted request event call to %s.Server.prototype.emit', moduleName)
 
-        var name = req.method + ' unknown route'
-        var trans = agent.startTransaction(name, traceType)
+        var trans = agent.startTransaction(null, traceType)
         trans.req = req
 
         if (agent.timeout.active) {
@@ -137,7 +136,7 @@ function prefinish (res, trans) {
         mountstack: req._opbeat_mountstack ? req._opbeat_mountstack.length : false,
         uuid: trans._uuid
       })
-      return
+      path = 'unknown route'
     }
 
     trans.setDefaultName(req.method + ' ' + path)

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -1,6 +1,10 @@
 'use strict'
 
+var semver = require('semver')
 var debug = require('debug')('opbeat')
+var shimmer = require('./shimmer')
+
+var SUPPORT_PREFINISH = semver.satisfies(process.version, '>=0.12')
 
 exports.instrumentRequest = function (agent, moduleName) {
   var traceType = 'web.' + moduleName
@@ -21,43 +25,18 @@ exports.instrumentRequest = function (agent, moduleName) {
           trans.timeout()
         })
 
-        res.on('prefinish', function () {
-          if (!trans._defaultName) {
-            var path
-
-            // Get proper route name from Express 4.x
-            if (req._opbeat_static) {
-              path = 'static file'
-            } else if (req.route) {
-              path = req.route.path || req.route.regexp && req.route.regexp.source || ''
-              if (req._opbeat_mountstack) path = req._opbeat_mountstack.join('') + (path === '/' ? '' : path)
-            } else if (req._opbeat_mountstack && req._opbeat_mountstack.length > 0) {
-              // in the case of custom middleware that terminates the request
-              // so it doesn't reach the regular router (like express-graphql),
-              // the req.route will not be set, but we'll see something on the
-              // mountstack and simply use that
-              path = req._opbeat_mountstack.join('')
+        if (SUPPORT_PREFINISH) {
+          res.on('prefinish', function () {
+            prefinish(res, trans)
+          })
+        } else {
+          shimmer.wrap(res, 'end', function wrapEnd (original) {
+            return function wrappedEnd () {
+              prefinish(res, trans)
+              return original.apply(this, arguments)
             }
-
-            if (!path) {
-              debug('could not extract route name from request %o', {
-                url: req.url,
-                type: typeof path,
-                null: path === null, // because typeof null === 'object'
-                route: !!req.route,
-                regex: req.route ? !!req.route.regexp : false,
-                mountstack: req._opbeat_mountstack ? req._opbeat_mountstack.length : false,
-                uuid: trans._uuid
-              })
-              path = 'unknown route'
-            }
-
-            trans.setDefaultName(req.method + ' ' + path)
-          }
-
-          trans.result = res.statusCode
-          trans._prefinish()
-        })
+          })
+        }
 
         res.on('finish', function () {
           trans._rootTrace.touch()
@@ -105,4 +84,43 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
       }
     }
   }
+}
+
+function prefinish (res, trans) {
+  if (!trans._defaultName) {
+    var req = trans.req
+    var path
+
+    // Get proper route name from Express 4.x
+    if (req._opbeat_static) {
+      path = 'static file'
+    } else if (req.route) {
+      path = req.route.path || req.route.regexp && req.route.regexp.source || ''
+      if (req._opbeat_mountstack) path = req._opbeat_mountstack.join('') + (path === '/' ? '' : path)
+    } else if (req._opbeat_mountstack && req._opbeat_mountstack.length > 0) {
+      // in the case of custom middleware that terminates the request
+      // so it doesn't reach the regular router (like express-graphql),
+      // the req.route will not be set, but we'll see something on the
+      // mountstack and simply use that
+      path = req._opbeat_mountstack.join('')
+    }
+
+    if (!path) {
+      debug('could not extract route name from request %o', {
+        url: req.url,
+        type: typeof path,
+        null: path === null, // because typeof null === 'object'
+        route: !!req.route,
+        regex: req.route ? !!req.route.regexp : false,
+        mountstack: req._opbeat_mountstack ? req._opbeat_mountstack.length : false,
+        uuid: trans._uuid
+      })
+      path = 'unknown route'
+    }
+
+    trans.setDefaultName(req.method + ' ' + path)
+  }
+
+  trans.result = res.statusCode
+  trans._prefinish()
 }

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -14,7 +14,8 @@ exports.instrumentRequest = function (agent, moduleName) {
       if (event === 'request') {
         debug('intercepted request event call to %s.Server.prototype.emit', moduleName)
 
-        var trans = agent.startTransaction(null, traceType)
+        var name = req.method + ' unknown route'
+        var trans = agent.startTransaction(name, traceType)
         trans.req = req
 
         if (agent.timeout.active) {
@@ -22,15 +23,32 @@ exports.instrumentRequest = function (agent, moduleName) {
             trans._aborted()
           })
 
-          res.on('timeout', function () {
-            trans.timeout()
+          // listening for the timeout event have side-effects, let's patch the
+          // emit function instead
+          shimmer.wrap(res, 'emit', function wrapEmit (original) {
+            return function wrappedEmit (event) {
+              switch (event) {
+                case 'timeout':
+                  // TODO: If the socket isn't close it appears that more than
+                  // one timeout event can be fired. This seems to occur if
+                  // someone writes to the socket after the timeout event have
+                  // fired. I guess this is because the timeout timer resets
+                  // after each write
+                  trans.timeout()
+                  break
+                case 'prefinish':
+                  prefinish(res, trans)
+                  break
+                case 'finish':
+                  trans._rootTrace.touch()
+                  trans.end()
+                  break
+              }
+              return original.apply(this, arguments)
+            }
           })
 
-          if (SUPPORT_PREFINISH) {
-            res.on('prefinish', function () {
-              prefinish(res, trans)
-            })
-          } else {
+          if (!SUPPORT_PREFINISH) {
             shimmer.wrap(res, 'end', function wrapEnd (original) {
               return function wrappedEnd () {
                 prefinish(res, trans)
@@ -38,11 +56,6 @@ exports.instrumentRequest = function (agent, moduleName) {
               }
             })
           }
-
-          res.on('finish', function () {
-            trans._rootTrace.touch()
-            trans.end()
-          })
         } else {
           res.on('finish', function () {
             prefinish(res, trans)
@@ -124,7 +137,7 @@ function prefinish (res, trans) {
         mountstack: req._opbeat_mountstack ? req._opbeat_mountstack.length : false,
         uuid: trans._uuid
       })
-      path = 'unknown route'
+      return
     }
 
     trans.setDefaultName(req.method + ' ' + path)

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -18,48 +18,68 @@ exports.instrumentRequest = function (agent, moduleName) {
         trans.req = req
 
         if (agent.timeout.active) {
-          req.on('aborted', function () {
-            trans._aborted()
-          })
+          var onClose = function onClose () {
+            if (trans.ended) return // listener should be removed, but just in case
 
-          // listening for the timeout event have side-effects, let's patch the
-          // emit function instead
-          shimmer.wrap(res, 'emit', function wrapEmit (original) {
-            return function wrappedEmit (event) {
-              switch (event) {
-                case 'timeout':
-                  // TODO: If the socket isn't close it appears that more than
-                  // one timeout event can be fired. This seems to occur if
-                  // someone writes to the socket after the timeout event have
-                  // fired. I guess this is because the timeout timer resets
-                  // after each write
-                  trans.timeout()
-                  break
-                case 'prefinish':
-                  prefinish(res, trans)
-                  break
-                case 'finish':
-                  trans._rootTrace.touch()
-                  trans.end()
-                  break
-              }
-              return original.apply(this, arguments)
+            var duration = Date.now() - trans._start
+
+            prefinish(res, trans)
+
+            if (duration > agent.timeout.errorThreshold) {
+              agent.captureError('Socket closed with active HTTP request (>' + (agent.timeout.errorThreshold / 1000) + ' sec)', {
+                request: req,
+                extra: { abortTime: duration }
+              })
+              trans.result = agent.timeout.errorResult
             }
-          })
 
-          if (!SUPPORT_PREFINISH) {
+            trans.end()
+
+            res.removeListener('finish', onFinish)
+            if (SUPPORT_PREFINISH) res.removeListener('prefinish', onPrefinish)
+            else shimmer.unwrap(res, 'end')
+          }
+
+          var onPrefinish = function onPrefinish () {
+            if (trans.ended) return // listener should be removed, but just in case
+            res.removeListener('close', onClose)
+            prefinish(res, trans)
+          }
+
+          var onFinish = function onFinish () {
+            if (trans.ended) return // listener should be removed, but just in case
+            trans._rootTrace.touch()
+            trans.end()
+          }
+
+          res.on('close', onClose)
+          res.on('finish', onFinish)
+
+          if (SUPPORT_PREFINISH) {
+            res.on('prefinish', onPrefinish)
+          } else {
             shimmer.wrap(res, 'end', function wrapEnd (original) {
               return function wrappedEnd () {
-                prefinish(res, trans)
+                onPrefinish()
                 return original.apply(this, arguments)
               }
             })
           }
         } else {
-          res.on('finish', function () {
-            prefinish(res, trans)
-            trans.end()
-          })
+          if (SUPPORT_PREFINISH) {
+            res.on('prefinish', function () {
+              prefinish(res, trans)
+              trans.end()
+            })
+          } else {
+            shimmer.wrap(res, 'end', function wrapEnd (original) {
+              return function wrappedEnd () {
+                prefinish(res, trans)
+                trans.end()
+                return original.apply(this, arguments)
+              }
+            })
+          }
         }
       }
 
@@ -143,5 +163,4 @@ function prefinish (res, trans) {
   }
 
   trans.result = res.statusCode
-  trans._prefinish()
 }

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -13,7 +13,7 @@ exports.instrumentRequest = function (agent, moduleName) {
         var trans = agent.startTransaction(null, traceType)
         trans.req = req
 
-        res.on('finish', function () {
+        res.on('prefinish', function () {
           if (!trans._defaultName) {
             var path
 
@@ -48,6 +48,11 @@ exports.instrumentRequest = function (agent, moduleName) {
           }
 
           trans.result = res.statusCode
+          trans._prefinish()
+        })
+
+        res.on('finish', function () {
+          trans._rootTrace.touch()
           trans.end()
         })
       }

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -17,31 +17,38 @@ exports.instrumentRequest = function (agent, moduleName) {
         var trans = agent.startTransaction(null, traceType)
         trans.req = req
 
-        req.on('aborted', function () {
-          trans._abored()
-        })
+        if (agent.timeout.active) {
+          req.on('aborted', function () {
+            trans._aborted()
+          })
 
-        res.on('timeout', function () {
-          trans.timeout()
-        })
+          res.on('timeout', function () {
+            trans.timeout()
+          })
 
-        if (SUPPORT_PREFINISH) {
-          res.on('prefinish', function () {
-            prefinish(res, trans)
+          if (SUPPORT_PREFINISH) {
+            res.on('prefinish', function () {
+              prefinish(res, trans)
+            })
+          } else {
+            shimmer.wrap(res, 'end', function wrapEnd (original) {
+              return function wrappedEnd () {
+                prefinish(res, trans)
+                return original.apply(this, arguments)
+              }
+            })
+          }
+
+          res.on('finish', function () {
+            trans._rootTrace.touch()
+            trans.end()
           })
         } else {
-          shimmer.wrap(res, 'end', function wrapEnd (original) {
-            return function wrappedEnd () {
-              prefinish(res, trans)
-              return original.apply(this, arguments)
-            }
+          res.on('finish', function () {
+            prefinish(res, trans)
+            trans.end()
           })
         }
-
-        res.on('finish', function () {
-          trans._rootTrace.touch()
-          trans.end()
-        })
       }
 
       orig.apply(this, arguments)

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -13,6 +13,10 @@ exports.instrumentRequest = function (agent, moduleName) {
         var trans = agent.startTransaction(null, traceType)
         trans.req = req
 
+        req.on('aborted', function () {
+          trans._abored()
+        })
+
         res.on('timeout', function () {
           trans.timeout()
         })

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -13,6 +13,10 @@ exports.instrumentRequest = function (agent, moduleName) {
         var trans = agent.startTransaction(null, traceType)
         trans.req = req
 
+        res.on('timeout', function () {
+          trans.timeout()
+        })
+
         res.on('prefinish', function () {
           if (!trans._defaultName) {
             var path

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -87,6 +87,8 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
 }
 
 function prefinish (res, trans) {
+  trans._rootTrace.touch()
+
   if (!trans._defaultName) {
     var req = trans.req
     var path

--- a/lib/instrumentation/shimmer.js
+++ b/lib/instrumentation/shimmer.js
@@ -6,6 +6,7 @@ var logger = require('debug')('opbeat')
 
 exports.wrap = wrap
 exports.massWrap = massWrap
+exports.unwrap = unwrap
 
 function isFunction (funktion) {
   return funktion && {}.toString.call(funktion) === '[object Function]'
@@ -37,6 +38,12 @@ function wrap (nodule, name, wrapper) {
   var wrapped = wrapper(original, name)
 
   wrapped.__obWrapped = true
+  wrapped.__obUnwrap = function __obUnwrap () {
+    if (nodule[name] === wrapped) {
+      nodule[name] = original
+      wrapped.__obWrapped = false
+    }
+  }
 
   nodule[name] = wrapped
 
@@ -62,4 +69,18 @@ function massWrap (nodules, names, wrapper) {
       wrap(nodule, name, wrapper)
     })
   })
+}
+
+function unwrap (nodule, name) {
+  if (!nodule || !nodule[name]) {
+    logger('no function to unwrap.')
+    logger((new Error()).stack)
+    return
+  }
+
+  if (!nodule[name].__obUnwrap) {
+    logger('no original to unwrap to -- has ' + name + ' already been unwrapped?')
+  } else {
+    return nodule[name].__obUnwrap()
+  }
 }

--- a/lib/instrumentation/shimmer.js
+++ b/lib/instrumentation/shimmer.js
@@ -28,7 +28,7 @@ function wrap (nodule, name, wrapper) {
     return
   }
 
-  if (nodule[name].__ob_wrapped) {
+  if (nodule[name].__obWrapped) {
     logger('function ' + name + ' already wrapped')
     return
   }
@@ -36,7 +36,7 @@ function wrap (nodule, name, wrapper) {
   var original = nodule[name]
   var wrapped = wrapper(original, name)
 
-  wrapped.__ob_wrapped = true
+  wrapped.__obWrapped = true
 
   nodule[name] = wrapped
 

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -8,6 +8,7 @@ module.exports = Trace
 function Trace (transaction) {
   this.transaction = transaction
   this.started = false
+  this.touched = false
   this.ended = false
   this.extra = {}
   this.signature = null
@@ -60,16 +61,26 @@ Trace.prototype._stacktraceGroupingKey = function () {
   return key
 }
 
-Trace.prototype.end = function () {
+Trace.prototype.touch = function () {
+  this.touched = true
+  this._diff = process.hrtime(this._hrtime)
+  this._agent._instrumentation._recoverTransaction(this.transaction)
+  debug('touched trace %o', { uuid: this.transaction._uuid, signature: this.signature, type: this.type })
+}
+
+Trace.prototype.end = function (_skipTouch) {
   if (this.ended) {
     debug('tried to end already ended trace - ignoring %o', { uuid: this.transaction._uuid, signature: this.signature, type: this.type })
     return
   }
-  this._diff = process.hrtime(this._hrtime)
-  this._agent._instrumentation._recoverTransaction(this.transaction)
+  if (!_skipTouch || !this.touched) this.touch()
   this.ended = true
   debug('ended trace %o', { uuid: this.transaction._uuid, signature: this.signature, type: this.type })
   this.transaction._recordEndedTrace(this)
+}
+
+Trace.prototype.softEnd = function () {
+  this.end(this.touched)
 }
 
 Trace.prototype.duration = function () {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -4,6 +4,8 @@ var uuid = require('node-uuid')
 var debug = require('debug')('opbeat')
 var Trace = require('./trace')
 
+var TIMEOUT_RESULT = 500
+var TIMEOUT_MIN_THRESHOLD = 25000
 var SOCKET_CLOSED_TIMEOUT = 120000
 var END_FLUSH_TIMEOUT = 10000
 
@@ -30,6 +32,7 @@ function Transaction (agent, name, type, result) {
   this.ended = false
   this._timeout = false
   this._endTimer = null
+  this._abortTime = 0
   this._uuid = uuid.v4()
   this._agent = agent
   this._agent._instrumentation.currentTransaction = this
@@ -45,10 +48,20 @@ function Transaction (agent, name, type, result) {
 }
 
 Transaction.prototype._aborted = function () {
+  this._abortTime = Date.now() - this._rootTrace._start
+
   clearTimeout(this._endTimer)
   this._endTimer = setTimeout(function (trans) {
     // We only reach this point if it's a client side timeout and `res.end()`
     // isn't called within 2 minutes
+    if (trans._abortTime > TIMEOUT_MIN_THRESHOLD) {
+      trans._agent.captureError('Transaction timeout', { extra: {
+        endCalled: false,
+        serverTimeout: false,
+        abortTime: trans._abortTime
+      }})
+      trans.result = TIMEOUT_RESULT
+    }
     trans.timeout()
   }, SOCKET_CLOSED_TIMEOUT, this).unref()
 }
@@ -60,12 +73,28 @@ Transaction.prototype._prefinish = function () {
   this._endTimer = setTimeout(function (trans) {
     // We only reach this point if it's a client side timeout and `res.end()`
     // was called
+    if (trans._abortTime > TIMEOUT_MIN_THRESHOLD) {
+      trans._agent.captureError('Transaction timeout', { extra: {
+        endCalled: true,
+        serverTimeout: false,
+        abortTime: trans._abortTime
+      }})
+    }
     trans.timeout()
   }, END_FLUSH_TIMEOUT, this).unref()
 }
 
 Transaction.prototype.timeout = function () {
   if (this.ended) return debug('cannot time out an already ended transaction %o', { uuid: this._uuid })
+
+  if (!this._endTimer || !this._endTimer._called) {
+    // it's a server-side timeout
+    this._agent.captureError('Transaction timeout', { extra: {
+      serverTimeout: true
+    }})
+    this.result = TIMEOUT_RESULT
+  }
+
   this._timeout = true
   this.end()
 }

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -4,6 +4,8 @@ var uuid = require('node-uuid')
 var debug = require('debug')('opbeat')
 var Trace = require('./trace')
 
+var END_FLUSH_TIMEOUT = 10000
+
 module.exports = Transaction
 
 function Transaction (agent, name, type, result) {
@@ -25,6 +27,8 @@ function Transaction (agent, name, type, result) {
   this.result = result
   this.traces = []
   this.ended = false
+  this._timeout = false
+  this._endTimer = null
   this._uuid = uuid.v4()
   this._agent = agent
   this._agent._instrumentation.currentTransaction = this
@@ -39,15 +43,34 @@ function Transaction (agent, name, type, result) {
   this.duration = this._rootTrace.duration.bind(this._rootTrace)
 }
 
+Transaction.prototype._prefinish = function () {
+  this._rootTrace.touch()
+
+  clearTimeout(this._endTimer)
+  this._endTimer = setTimeout(function (trans) {
+    // We only reach this point if it's a client side timeout and `res.end()`
+    // was called
+    trans.timeout()
+  }, END_FLUSH_TIMEOUT, this).unref()
+}
+
+Transaction.prototype.timeout = function () {
+  if (this.ended) return debug('cannot time out an already ended transaction %o', { uuid: this._uuid })
+  this._timeout = true
+  this.end()
+}
+
 Transaction.prototype.setDefaultName = function (name) {
   debug('setting default transaction name: %s %o', name, { uuid: this._uuid })
   this._defaultName = name
 }
 
 Transaction.prototype.end = function () {
-  if (this.ended) return debug('cannot end already ended transaction %o', { uuid: this._uuid })
+  if (this.ended) return debug('cannot end already ended transaction %o', { uuid: this._uuid, timeout: this._timeout })
 
-  this._rootTrace.end()
+  clearTimeout(this._endTimer)
+
+  this._rootTrace.softEnd()
   this.ended = true
 
   var trans = this._agent._instrumentation.currentTransaction
@@ -66,7 +89,7 @@ Transaction.prototype.end = function () {
   }
 
   this._agent._instrumentation.addEndedTransaction(this)
-  debug('ended transaction %o', { uuid: this._uuid, type: this.type, result: this.result, name: this.name })
+  debug('ended transaction %o', { uuid: this._uuid, type: this.type, result: this.result, name: this.name, timeout: this._timeout })
 }
 
 Transaction.prototype._recordEndedTrace = function (trace) {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -7,7 +7,6 @@ var Trace = require('./trace')
 var TIMEOUT_RESULT = 500
 var TIMEOUT_MIN_THRESHOLD = 25000
 var SOCKET_CLOSED_TIMEOUT = 120000
-var END_FLUSH_TIMEOUT = 10000
 
 module.exports = Transaction
 
@@ -31,6 +30,7 @@ function Transaction (agent, name, type, result) {
   this.traces = []
   this.ended = false
   this._timeout = false
+  this._prefinished = false
   this._endTimer = null
   this._abortTime = 0
   this._uuid = uuid.v4()
@@ -48,6 +48,8 @@ function Transaction (agent, name, type, result) {
 }
 
 Transaction.prototype._aborted = function () {
+  if (this.ended) return debug('cannot call _aborted an already ended transaction %o', { uuid: this._uuid })
+
   this._abortTime = Date.now() - this._rootTrace._start
 
   clearTimeout(this._endTimer)
@@ -67,27 +69,33 @@ Transaction.prototype._aborted = function () {
 }
 
 Transaction.prototype._prefinish = function () {
-  this._rootTrace.touch()
+  if (this.ended) return debug('cannot call _prefinish an already ended transaction %o', { uuid: this._uuid })
 
-  clearTimeout(this._endTimer)
-  this._endTimer = setTimeout(function (trans) {
-    // We only reach this point if it's a client side timeout and `res.end()`
-    // was called
-    if (trans._abortTime > TIMEOUT_MIN_THRESHOLD) {
-      trans._agent.captureError('Transaction timeout', { extra: {
+  this._prefinished = true
+
+  if (this._abortTime) {
+    // `this._abortTime` is set for both server and client-side timeouts, but
+    // server-side timeouts will set the `this.ended` boolean to true wihtin
+    // the same tick, so we'll only reach this point if it's a client side
+    // timeout and `res.end()` was called
+    clearTimeout(this._endTimer)
+
+    if (this._abortTime > TIMEOUT_MIN_THRESHOLD) {
+      this._agent.captureError('Transaction timeout', { extra: {
         endCalled: true,
         serverTimeout: false,
-        abortTime: trans._abortTime
+        abortTime: this._abortTime
       }})
     }
-    trans.timeout()
-  }, END_FLUSH_TIMEOUT, this).unref()
+
+    this.timeout()
+  }
 }
 
 Transaction.prototype.timeout = function () {
   if (this.ended) return debug('cannot time out an already ended transaction %o', { uuid: this._uuid })
 
-  if (!this._endTimer || !this._endTimer._called) {
+  if (!this._prefinished && (this._endTimer || !this._endTimer._called)) {
     // it's a server-side timeout
     this._agent.captureError('Transaction timeout', { extra: {
       serverTimeout: true

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -4,6 +4,7 @@ var uuid = require('node-uuid')
 var debug = require('debug')('opbeat')
 var Trace = require('./trace')
 
+var SOCKET_CLOSED_TIMEOUT = 120000
 var END_FLUSH_TIMEOUT = 10000
 
 module.exports = Transaction
@@ -41,6 +42,15 @@ function Transaction (agent, name, type, result) {
   this._rootTrace.start('transaction', 'transaction')
   this._start = this._rootTrace._start
   this.duration = this._rootTrace.duration.bind(this._rootTrace)
+}
+
+Transaction.prototype._aborted = function () {
+  clearTimeout(this._endTimer)
+  this._endTimer = setTimeout(function (trans) {
+    // We only reach this point if it's a client side timeout and `res.end()`
+    // isn't called within 2 minutes
+    trans.timeout()
+  }, SOCKET_CLOSED_TIMEOUT, this).unref()
 }
 
 Transaction.prototype._prefinish = function () {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -25,10 +25,6 @@ function Transaction (agent, name, type, result) {
   this.result = result
   this.traces = []
   this.ended = false
-  this._timeout = false
-  this._prefinished = false
-  this._abortedTimeout = false
-  this._endTimer = null
   this._abortTime = 0
   this._uuid = uuid.v4()
   this._agent = agent
@@ -44,78 +40,13 @@ function Transaction (agent, name, type, result) {
   this.duration = this._rootTrace.duration.bind(this._rootTrace)
 }
 
-Transaction.prototype._aborted = function () {
-  if (this.ended) return debug('cannot call _aborted an already ended transaction %o', { uuid: this._uuid })
-
-  this._abortTime = Date.now() - this._rootTrace._start
-
-  clearTimeout(this._endTimer)
-  this._endTimer = setTimeout(function (trans) {
-    trans._abortedTimeout = true
-    // We only reach this point if it's a client side timeout and `res.end()`
-    // isn't called within 2 minutes
-    if (trans._abortTime > trans._agent.timeout.errorThreshold) {
-      trans._agent.captureError('Transaction timeout', { extra: {
-        endCalled: false,
-        serverTimeout: false,
-        abortTime: trans._abortTime
-      }})
-      trans.result = trans._agent.timeout.errorResult
-    } else if (trans.result === undefined) {
-      trans.result = trans._agent.timeout.errorResult
-    }
-    trans.timeout()
-  }, this._agent.timeout.socketClosedDelay, this).unref()
-}
-
-Transaction.prototype._prefinish = function () {
-  if (this.ended) return debug('cannot call _prefinish an already ended transaction %o', { uuid: this._uuid })
-
-  this._prefinished = true
-
-  if (this._abortTime) {
-    // `this._abortTime` is set for both server and client-side timeouts, but
-    // server-side timeouts will set the `this.ended` boolean to true wihtin
-    // the same tick, so we'll only reach this point if it's a client side
-    // timeout and `res.end()` was called
-    clearTimeout(this._endTimer)
-
-    if (this._abortTime > this._agent.timeout.errorThreshold) {
-      this._agent.captureError('Transaction timeout', { extra: {
-        endCalled: true,
-        serverTimeout: false,
-        abortTime: this._abortTime
-      }})
-    }
-
-    this.timeout()
-  }
-}
-
-Transaction.prototype.timeout = function () {
-  if (this.ended) return debug('cannot time out an already ended transaction %o', { uuid: this._uuid })
-
-  if (!this._prefinished && !this._abortedTimeout) {
-    // it's a server-side timeout
-    this._agent.captureError('Transaction timeout', { extra: {
-      serverTimeout: true
-    }})
-    this.result = this._agent.timeout.errorResult
-  }
-
-  this._timeout = true
-  this.end()
-}
-
 Transaction.prototype.setDefaultName = function (name) {
   debug('setting default transaction name: %s %o', name, { uuid: this._uuid })
   this._defaultName = name
 }
 
 Transaction.prototype.end = function () {
-  if (this.ended) return debug('cannot end already ended transaction %o', { uuid: this._uuid, timeout: this._timeout })
-
-  clearTimeout(this._endTimer)
+  if (this.ended) return debug('cannot end already ended transaction %o', { uuid: this._uuid })
 
   this._rootTrace.softEnd()
   this.ended = true
@@ -136,7 +67,7 @@ Transaction.prototype.end = function () {
   }
 
   this._agent._instrumentation.addEndedTransaction(this)
-  debug('ended transaction %o', { uuid: this._uuid, type: this.type, result: this.result, name: this.name, timeout: this._timeout })
+  debug('ended transaction %o', { uuid: this._uuid, type: this.type, result: this.result, name: this.name })
 }
 
 Transaction.prototype._recordEndedTrace = function (trace) {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -4,10 +4,6 @@ var uuid = require('node-uuid')
 var debug = require('debug')('opbeat')
 var Trace = require('./trace')
 
-var TIMEOUT_RESULT = 500
-var TIMEOUT_MIN_THRESHOLD = 25000
-var SOCKET_CLOSED_TIMEOUT = 120000
-
 module.exports = Transaction
 
 function Transaction (agent, name, type, result) {
@@ -56,16 +52,16 @@ Transaction.prototype._aborted = function () {
   this._endTimer = setTimeout(function (trans) {
     // We only reach this point if it's a client side timeout and `res.end()`
     // isn't called within 2 minutes
-    if (trans._abortTime > TIMEOUT_MIN_THRESHOLD) {
+    if (trans._abortTime > trans._agent.timeout.errorThreshold) {
       trans._agent.captureError('Transaction timeout', { extra: {
         endCalled: false,
         serverTimeout: false,
         abortTime: trans._abortTime
       }})
-      trans.result = TIMEOUT_RESULT
+      trans.result = trans._agent.timeout.errorResult
     }
     trans.timeout()
-  }, SOCKET_CLOSED_TIMEOUT, this).unref()
+  }, this._agent.timeout.socketClosedDelay, this).unref()
 }
 
 Transaction.prototype._prefinish = function () {
@@ -80,7 +76,7 @@ Transaction.prototype._prefinish = function () {
     // timeout and `res.end()` was called
     clearTimeout(this._endTimer)
 
-    if (this._abortTime > TIMEOUT_MIN_THRESHOLD) {
+    if (this._abortTime > this._agent.timeout.errorThreshold) {
       this._agent.captureError('Transaction timeout', { extra: {
         endCalled: true,
         serverTimeout: false,
@@ -100,7 +96,7 @@ Transaction.prototype.timeout = function () {
     this._agent.captureError('Transaction timeout', { extra: {
       serverTimeout: true
     }})
-    this.result = TIMEOUT_RESULT
+    this.result = this._agent.timeout.errorResult
   }
 
   this._timeout = true

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -27,6 +27,7 @@ function Transaction (agent, name, type, result) {
   this.ended = false
   this._timeout = false
   this._prefinished = false
+  this._abortedTimeout = false
   this._endTimer = null
   this._abortTime = 0
   this._uuid = uuid.v4()
@@ -50,6 +51,7 @@ Transaction.prototype._aborted = function () {
 
   clearTimeout(this._endTimer)
   this._endTimer = setTimeout(function (trans) {
+    trans._abortedTimeout = true
     // We only reach this point if it's a client side timeout and `res.end()`
     // isn't called within 2 minutes
     if (trans._abortTime > trans._agent.timeout.errorThreshold) {
@@ -93,7 +95,7 @@ Transaction.prototype._prefinish = function () {
 Transaction.prototype.timeout = function () {
   if (this.ended) return debug('cannot time out an already ended transaction %o', { uuid: this._uuid })
 
-  if (!this._prefinished && (this._endTimer || !this._endTimer._called)) {
+  if (!this._prefinished && !this._abortedTimeout) {
     // it's a server-side timeout
     this._agent.captureError('Transaction timeout', { extra: {
       serverTimeout: true

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -59,6 +59,8 @@ Transaction.prototype._aborted = function () {
         abortTime: trans._abortTime
       }})
       trans.result = trans._agent.timeout.errorResult
+    } else if (trans.result === undefined) {
+      trans.result = trans._agent.timeout.errorResult
     }
     trans.timeout()
   }, this._agent.timeout.socketClosedDelay, this).unref()

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -12,7 +12,12 @@ module.exports = function mockAgent (cb) {
   var agent = {
     active: true,
     instrument: true,
-    timeout: { active: false },
+    timeout: {
+      active: false,
+      errorResult: 42,
+      errorThreshold: 500,
+      socketClosedDelay: 800
+    },
     _httpClient: {
       request: cb || noop
     }

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -15,8 +15,7 @@ module.exports = function mockAgent (cb) {
     timeout: {
       active: false,
       errorResult: 42,
-      errorThreshold: 500,
-      socketClosedDelay: 800
+      errorThreshold: 250
     },
     _httpClient: {
       request: cb || noop

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -12,6 +12,7 @@ module.exports = function mockAgent (cb) {
   var agent = {
     active: true,
     instrument: true,
+    timeout: { active: false },
     _httpClient: {
       request: cb || noop
     }

--- a/test/instrumentation/modules/http/_assert.js
+++ b/test/instrumentation/modules/http/_assert.js
@@ -1,0 +1,33 @@
+'use strict'
+
+module.exports = assert
+
+// {
+//   traces: {
+//     groups: [ { extra: { _frames: [Object] }, kind: 'transaction', parents: [], signature: 'transaction', timestamp: '2016-06-14T22:34:00.000Z', transaction: 'GET unknown route' } ],
+//     raw: [ [ 5.404068, [ 0, 0, 5.404068 ] ] ]
+//   },
+//   transactions: [ { durations: [ 5.404068 ], kind: 'web.http', result: 200, timestamp: '2016-06-14T22:34:00.000Z', transaction: 'GET unknown route' } ]
+// }
+function assert (t, data, results) {
+  if (!results) results = {}
+
+  t.equal(data.transactions[0].kind, 'web.http')
+  t.equal(data.transactions[0].result, results.result || 200)
+  t.equal(data.transactions[0].transaction, 'GET unknown route')
+
+  t.equal(data.traces.groups.length, 1)
+  t.equal(data.traces.raw.length, 1)
+  t.equal(data.transactions.length, 1)
+  t.equal(data.traces.groups[0].kind, 'transaction')
+  t.deepEqual(data.traces.groups[0].parents, [])
+  t.equal(data.traces.groups[0].signature, 'transaction')
+  t.equal(data.traces.groups[0].transaction, 'GET unknown route')
+
+  t.equal(data.traces.raw[0].length, 2)
+  t.equal(data.traces.raw[0][1].length, 3)
+  t.equal(data.traces.raw[0][1][0], 0)
+  t.equal(data.traces.raw[0][1][1], 0)
+  t.equal(data.traces.raw[0][1][2], data.traces.raw[0][0])
+  t.deepEqual(data.transactions[0].durations, [data.traces.raw[0][0]])
+}

--- a/test/instrumentation/modules/http/timeout-disabled.js
+++ b/test/instrumentation/modules/http/timeout-disabled.js
@@ -1,0 +1,121 @@
+'use strict'
+
+var agent = require('../../_agent')()
+
+var test = require('tape')
+var http = require('http')
+
+agent.timeout.active = false
+
+test('client-side timeout - call end', function (t) {
+  agent._instrumentation._queue = []
+  var clientReq
+
+  var server = http.createServer(function (req, res) {
+    clientReq.abort()
+    res.write('Hello')
+    setTimeout(function () {
+      res.end(' World')
+    }, 10)
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      setTimeout(function () {
+        t.equal(agent._instrumentation._queue.length, 0, 'should not add transactions to queue')
+        server.close()
+        t.end()
+      }, agent.timeout.socketClosedDelay + 100)
+    })
+  })
+})
+
+test('client-side timeout - don\'t call end', function (t) {
+  agent._instrumentation._queue = []
+  var clientReq
+
+  var server = http.createServer(function (req, res) {
+    clientReq.abort()
+    res.write('Hello')
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      setTimeout(function () {
+        t.equal(agent._instrumentation._queue.length, 0, 'should not add transactions to queue')
+        server.close()
+        t.end()
+      }, agent.timeout.socketClosedDelay + 100)
+    })
+  })
+})
+
+test('server-side timeout - call end', function (t) {
+  agent._instrumentation._queue = []
+  var timedout = false
+  var ended = false
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      t.ok(timedout, 'should have closed socket')
+      res.end('Hello World')
+      ended = true
+    }, agent.timeout.socketClosedDelay + 100)
+  })
+
+  server.setTimeout(agent.timeout.socketClosedDelay)
+
+  server.listen(function () {
+    var port = server.address().port
+    var clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      timedout = true
+      setTimeout(function () {
+        t.ok(ended, 'should have called res.end')
+        t.equal(agent._instrumentation._queue.length, 0, 'should not add transactions to queue')
+        server.close()
+        t.end()
+      }, 100)
+    })
+  })
+})
+
+test('server-side timeout - don\'t call end', function (t) {
+  agent._instrumentation._queue = []
+  var timedout = false
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      t.ok(timedout, 'should have closed socket')
+      t.equal(agent._instrumentation._queue.length, 0, 'should not add transactions to queue')
+      server.close()
+      t.end()
+    }, agent.timeout.socketClosedDelay + 100)
+  })
+
+  server.setTimeout(agent.timeout.socketClosedDelay)
+
+  server.listen(function () {
+    var port = server.address().port
+    var clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      timedout = true
+    })
+  })
+})

--- a/test/instrumentation/modules/http/timeout-enabled.js
+++ b/test/instrumentation/modules/http/timeout-enabled.js
@@ -1,0 +1,338 @@
+'use strict'
+
+var agent = require('../../_agent')()
+
+var assert = require('./_assert')
+var test = require('tape')
+var http = require('http')
+
+agent.timeout.active = true
+
+test('client-side timeout below error threshold - call end', function (t) {
+  t.plan(17)
+
+  resetAgent(function (endpoint, data, cb) {
+    assert(t, data)
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) { // eslint-disable-line handle-callback-err
+    t.fail('should not register the timeout as an error')
+  }
+  var clientReq
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      clientReq.abort()
+      res.write('Hello')
+      setTimeout(function () {
+        res.end(' World')
+      }, 10)
+    }, agent.timeout.errorThreshold / 2)
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      setTimeout(function () {
+        t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+        agent._instrumentation._send()
+      }, agent.timeout.socketClosedDelay + 100)
+    })
+  })
+})
+
+test('client-side timeout above error threshold - call end', function (t) {
+  t.plan(21)
+
+  resetAgent(function (endpoint, data, cb) {
+    assert(t, data)
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) {
+    t.equal(err, 'Transaction timeout')
+    t.equal(opts.extra.endCalled, true)
+    t.equal(opts.extra.serverTimeout, false)
+    t.ok(opts.extra.abortTime > 0)
+  }
+  var clientReq
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      // clientReq.abort()
+      // clientReq.socket.destroy()
+      req.socket.destroy()
+      res.write('Hello')
+      setTimeout(function () {
+        res.end(' World')
+      }, 10)
+    }, agent.timeout.errorThreshold + 10)
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      setTimeout(function () {
+        t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+        agent._instrumentation._send()
+      }, agent.timeout.socketClosedDelay + 100)
+    })
+  })
+})
+
+test('client-side timeout below error threshold - don\'t call end', function (t) {
+  t.plan(17)
+
+  resetAgent(function (endpoint, data, cb) {
+    assert(t, data, { result: 42 })
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) { // eslint-disable-line handle-callback-err
+    t.fail('should not register the timeout as an error')
+  }
+  var clientReq
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      clientReq.abort()
+      setTimeout(function () {
+        res.write('Hello') // server emits clientError if written in same tick as abort
+      }, 10)
+    }, agent.timeout.errorThreshold / 2)
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      setTimeout(function () {
+        t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+        agent._instrumentation._send()
+      }, agent.timeout.socketClosedDelay + 100)
+    })
+  })
+})
+
+test('client-side timeout above error threshold - don\'t call end', function (t) {
+  t.plan(21)
+
+  resetAgent(function (endpoint, data, cb) {
+    assert(t, data, { result: 42 })
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) {
+    t.equal(err, 'Transaction timeout')
+    t.equal(opts.extra.endCalled, false)
+    t.equal(opts.extra.serverTimeout, false)
+    t.ok(opts.extra.abortTime > 0)
+  }
+  var clientReq
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      clientReq.abort()
+      setTimeout(function () {
+        res.write('Hello') // server emits clientError if written in same tick as abort
+      }, 10)
+    }, agent.timeout.errorThreshold + 10)
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      setTimeout(function () {
+        t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+        agent._instrumentation._send()
+      }, agent.timeout.socketClosedDelay + 100)
+    })
+  })
+})
+
+test('server-side timeout and socket closed - call end', function (t) {
+  t.plan(20)
+
+  var timedout = false
+
+  resetAgent(function (endpoint, data, cb) {
+    assert(t, data, { result: 42 })
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) {
+    t.equal(err, 'Transaction timeout')
+    t.equal(opts.extra.serverTimeout, true)
+  }
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      t.ok(timedout, 'should have closed socket')
+      res.end('Hello World')
+    }, agent.timeout.socketClosedDelay + 100)
+  })
+
+  server.setTimeout(agent.timeout.socketClosedDelay)
+
+  server.listen(function () {
+    var port = server.address().port
+    var clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      timedout = true
+      t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+      agent._instrumentation._send()
+    })
+  })
+})
+
+test('server-side timeout and socket closed - don\'t call end', function (t) {
+  t.plan(20)
+
+  var timedout = false
+
+  resetAgent(function (endpoint, data, cb) {
+    assert(t, data, { result: 42 })
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) {
+    t.equal(err, 'Transaction timeout')
+    t.equal(opts.extra.serverTimeout, true)
+  }
+
+  var server = http.createServer(function (req, res) {
+    setTimeout(function () {
+      t.ok(timedout, 'should have closed socket')
+    }, agent.timeout.socketClosedDelay + 100)
+  })
+
+  server.setTimeout(agent.timeout.socketClosedDelay)
+
+  server.listen(function () {
+    var port = server.address().port
+    var clientReq = http.get('http://localhost:' + port, function (res) {
+      t.fail('should not call http.get callback')
+    })
+    clientReq.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') throw err
+      timedout = true
+      t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+      agent._instrumentation._send()
+    })
+  })
+})
+
+test('server-side timeout but socket not closed - call end', function (t) {
+  t.plan(19)
+
+  resetAgent(function (endpoint, data, cb) {
+    assert(t, data)
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) {
+    t.equal(err, 'Transaction timeout')
+    t.equal(opts.extra.serverTimeout, true)
+  }
+
+  var server = http.createServer(function (req, res) {
+    // listening on for the timeout event on either the server or the response
+    // will hinder the socket from closing automatically when a timeout occurs
+    res.on('timeout', function () {})
+
+    setTimeout(function () {
+      res.end('Hello World')
+    }, agent.timeout.socketClosedDelay + 100)
+  })
+
+  server.setTimeout(agent.timeout.socketClosedDelay)
+
+  server.listen(function () {
+    var port = server.address().port
+    var clientReq = http.get('http://localhost:' + port, function (res) {
+      res.resume()
+      clientReq.on('close', function () {
+        t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+        agent._instrumentation._send()
+      })
+    })
+  })
+})
+
+test('server-side timeout but socket not closed - don\'t call end', function (t) {
+  t.plan(23)
+
+  var timeouts = 0
+  var clientReq
+
+  resetAgent(function (endpoint, data, cb) {
+    t.equal(timeouts, 2)
+    assert(t, data)
+    clientReq.abort()
+    server.close()
+  })
+
+  agent.captureError = function (err, opts) {
+    t.equal(err, 'Transaction timeout')
+    t.equal(opts.extra.serverTimeout, true)
+  }
+
+  var server = http.createServer(function (req, res) {
+    // listening on for the timeout event on either the server or the response
+    // will hinder the socket from closing automatically when a timeout occurs
+    res.on('timeout', function () {
+      timeouts++
+    })
+
+    res.write('Hello')
+    setTimeout(function () {
+      t.equal(timeouts, 1)
+      res.write(' World')
+    }, agent.timeout.socketClosedDelay + 100)
+  })
+
+  server.setTimeout(agent.timeout.socketClosedDelay)
+
+  server.listen(function () {
+    var port = server.address().port
+    clientReq = http.get('http://localhost:' + port, function (res) {
+      res.once('data', function (chunk) {
+        t.equal(chunk.toString(), 'Hello')
+        res.once('data', function (chunk) {
+          t.equal(chunk.toString(), ' World')
+          setTimeout(function () {
+            t.equal(agent._instrumentation._queue.length, 1, 'should add transactions to queue')
+            agent._instrumentation._send()
+          }, agent.timeout.socketClosedDelay + 100)
+        })
+      })
+    })
+  })
+})
+
+test('server-side timeout but socket not closed and then client-side timeout - call end')
+test('server-side timeout but socket not closed and then client-side timeout - don\'t call end')
+
+function resetAgent (cb) {
+  agent._instrumentation._queue = []
+  agent._httpClient = { request: cb }
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -18,6 +18,10 @@ for file in $(files test/instrumentation/modules/!(_*).js); do
   node "$file" || exit $?;
 done
 
+for file in $(files test/instrumentation/modules/http/!(_*).js); do
+  node "$file" || exit $?;
+done
+
 for file in $(files test/instrumentation/modules/mysql/!(_*).js); do
   node "$file" || exit $?;
 done


### PR DESCRIPTION
This PR allows HTTP related transactions whos underlying socket have timed out to still be captured by Opbeat.

Besides capturing the transactions, an error is also logged letting the user know exactly which HTTP request that timed out.

To-do:

- [x] ~~Capture client timeout transactions~~
- [x] ~~Capture server timeout transactions~~
- [x] ~~Time out and capture transactions where the underlying request was never ended~~
- [x] Log timed out transaction as an error
- [x] Support Node.js v0.10
- [x] Allow the user to enable/disable this feature
- [x] ~~Allow the user to change the default timer thresholds~~
- [x] Add tests
- [x] New: simply detect if a socket is closed before the active request is ended