### PR TITLE
[RFR] OPBEAT_CONFIG_FILE to select filepath in opbeat/start

### DIFF
--- a/start.js
+++ b/start.js
@@ -4,7 +4,7 @@ var path = require('path')
 var fs = require('fs')
 var opbeat = require('./')
 
-var filepath = path.resolve('opbeat.js')
+var filepath = path.resolve(process.env.OPBEAT_CONFIG_FILE || 'opbeat.js')
 
 if (fs.existsSync(filepath)) opbeat.start(require(filepath))
 else opbeat.start()


### PR DESCRIPTION
Usage:
```js
import opbeat from 'opbeat/start';
```

```bash
OPBEAT_CONFIG_FILE="build/opbeat.js" node --require opbeat/start app.js
```