### PR TITLE
Allow server event handlers in connectionless hapi server

### DIFF
--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -58,7 +58,7 @@ module.exports = function (hapi, agent, version) {
         debug('unable to enable hapi error tracking')
       }
 
-      // When the haoi server has no connections we don't make connection
+      // When the hapi server has no connections we don't make connection
       // lifecycle hooks
       if (this.connections.length === 0) {
         debug('unable to enable hapi instrumentation on connectionless server')

--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -16,11 +16,56 @@ module.exports = function (hapi, agent, version) {
 
   shimmer.wrap(hapi.Server.prototype, 'initialize', function (orig) {
     return function () {
+      // Hooks that are always allowed
+      if (typeof this.on === 'function') {
+        this.on('request-error', function (req, err) {
+          agent.captureError(err, {request: req.raw && req.raw.req})
+        })
+
+        this.on('log', function (event, tags) {
+          if (!event || !tags.error) return
+
+          var payload = {extra: event}
+
+          payload.extra.tags = tags
+
+          var err = event.data
+          if (!(err instanceof Error) && typeof err !== 'string') {
+            err = 'hapi server emitted a log event tagged error'
+          }
+
+          agent.captureError(err, payload)
+        })
+
+        this.on('request', function (req, event, tags) {
+          if (!event || !tags.error) return
+
+          var payload = {
+            extra: event,
+            request: req.raw && req.raw.req
+          }
+
+          payload.extra.tags = tags
+
+          var err = event.data
+          if (!(err instanceof Error) && typeof err !== 'string') {
+            err = 'hapi server emitted a request event tagged error'
+          }
+
+          agent.captureError(err, payload)
+        })
+      } else {
+        debug('unable to enable hapi error tracking')
+      }
+
+      // When the haoi server has no connections we don't make connection
+      // lifecycle hooks
       if (this.connections.length === 0) {
         debug('unable to enable hapi instrumentation on connectionless server')
         return orig.apply(this, arguments)
       }
 
+      // Hooks that are only allowed when the hapi server has connections
       if (typeof this.ext === 'function') {
         this.ext('onPreAuth', function (request, reply) {
           debug('received hapi onPreAuth event')
@@ -75,47 +120,6 @@ module.exports = function (hapi, agent, version) {
         })
       } else {
         debug('unable to enable automatic hapi transaction naming')
-      }
-
-      if (typeof this.on === 'function') {
-        this.on('request-error', function (req, err) {
-          agent.captureError(err, {request: req.raw && req.raw.req})
-        })
-
-        this.on('log', function (event, tags) {
-          if (!event || !tags.error) return
-
-          var payload = {extra: event}
-
-          payload.extra.tags = tags
-
-          var err = event.data
-          if (!(err instanceof Error) && typeof err !== 'string') {
-            err = 'hapi server emitted a log event tagged error'
-          }
-
-          agent.captureError(err, payload)
-        })
-
-        this.on('request', function (req, event, tags) {
-          if (!event || !tags.error) return
-
-          var payload = {
-            extra: event,
-            request: req.raw && req.raw.req
-          }
-
-          payload.extra.tags = tags
-
-          var err = event.data
-          if (!(err instanceof Error) && typeof err !== 'string') {
-            err = 'hapi server emitted a request event tagged error'
-          }
-
-          agent.captureError(err, payload)
-        })
-      } else {
-        debug('unable to enable hapi error tracking')
       }
 
       return orig.apply(this, arguments)

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -49,6 +49,86 @@ test('connectionless', function (t) {
   })
 })
 
+test('connectionless server error logging with Error', function (t) {
+  t.plan(6)
+
+  var customError = new Error('custom error')
+
+  resetAgent()
+
+  agent.captureError = function (err, opts) {
+    server.stop()
+
+    t.equal(err, customError)
+    t.ok(opts.extra)
+    t.deepEqual(opts.extra.tags, { error: true })
+    t.false(opts.extra.internals)
+    t.ok(opts.extra.data instanceof Error)
+  }
+
+  var server = new Hapi.Server()
+
+  server.initialize(function (err) {
+    t.error(err, 'start error')
+
+    server.log(['error'], customError)
+  })
+})
+
+test('connectionless server error logging with String', function (t) {
+  t.plan(6)
+
+  var customError = 'custom error'
+
+  resetAgent()
+
+  agent.captureError = function (err, opts) {
+    server.stop()
+
+    t.equal(err, customError)
+    t.ok(opts.extra)
+    t.deepEqual(opts.extra.tags, { error: true })
+    t.false(opts.extra.internals)
+    t.ok(typeof opts.extra.data === 'string')
+  }
+
+  var server = new Hapi.Server()
+
+  server.initialize(function (err) {
+    t.error(err, 'start error')
+
+    server.log(['error'], customError)
+  })
+})
+
+test('connectionless server error logging with Object', function (t) {
+  t.plan(6)
+
+  var customError = {
+    error: 'I forgot to turn this into an actual Error'
+  }
+
+  resetAgent()
+
+  agent.captureError = function (err, opts) {
+    server.stop()
+
+    t.equal(err, 'hapi server emitted a log event tagged error')
+    t.ok(opts.extra)
+    t.deepEqual(opts.extra.tags, { error: true })
+    t.false(opts.extra.internals)
+    t.deepEqual(opts.extra.data, customError)
+  }
+
+  var server = new Hapi.Server()
+
+  server.initialize(function (err) {
+    t.error(err, 'start error')
+
+    server.log(['error'], customError)
+  })
+})
+
 test('server error logging with Error', function (t) {
   t.plan(6)
 


### PR DESCRIPTION
Only `server.ext()` is not allowed when there are no connections but we do still want to handle log events (mainly from `server.log`)
If you think the solution is right I'll add tests :P