### PR TITLE
fix(hapi): do not overwrite tags of events

### DIFF
--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -27,8 +27,6 @@ module.exports = function (hapi, agent, version) {
 
           var payload = {extra: event}
 
-          payload.extra.tags = tags
-
           var err = event.data
           if (!(err instanceof Error) && typeof err !== 'string') {
             err = 'hapi server emitted a log event tagged error'
@@ -44,8 +42,6 @@ module.exports = function (hapi, agent, version) {
             extra: event,
             request: req.raw && req.raw.req
           }
-
-          payload.extra.tags = tags
 
           var err = event.data
           if (!(err instanceof Error) && typeof err !== 'string') {

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -61,7 +61,7 @@ test('connectionless server error logging with Error', function (t) {
 
     t.equal(err, customError)
     t.ok(opts.extra)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.ok(opts.extra.data instanceof Error)
   }
@@ -87,7 +87,7 @@ test('connectionless server error logging with String', function (t) {
 
     t.equal(err, customError)
     t.ok(opts.extra)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.ok(typeof opts.extra.data === 'string')
   }
@@ -115,7 +115,7 @@ test('connectionless server error logging with Object', function (t) {
 
     t.equal(err, 'hapi server emitted a log event tagged error')
     t.ok(opts.extra)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.deepEqual(opts.extra.data, customError)
   }
@@ -141,7 +141,7 @@ test('server error logging with Error', function (t) {
 
     t.equal(err, customError)
     t.ok(opts.extra)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.ok(opts.extra.data instanceof Error)
   }
@@ -156,6 +156,41 @@ test('server error logging with Error', function (t) {
   })
 })
 
+test('server error logging with Error does not affect event tags', function (t) {
+    t.plan(8)
+
+    var customError = new Error('custom error')
+
+    resetAgent()
+
+    agent.captureError = function (err, opts) {
+      server.stop()
+
+      t.equal(err, customError)
+      t.ok(opts.extra)
+      t.deepEqual(opts.extra.tags, ['error'])
+      t.false(opts.extra.internals)
+      t.ok(opts.extra.data instanceof Error)
+    }
+
+    var server = new Hapi.Server()
+    server.connection()
+
+    server.on('log', function (event, tags) {
+        t.deepEqual(event.tags, ['error']);
+    })
+
+    server.start(function (err) {
+      t.error(err, 'start error')
+
+      server.on('log', function (event, tags) {
+          t.deepEqual(event.tags, ['error']);
+      })
+
+      server.log(['error'], customError)
+    })
+})
+
 test('server error logging with String', function (t) {
   t.plan(6)
 
@@ -168,7 +203,7 @@ test('server error logging with String', function (t) {
 
     t.equal(err, customError)
     t.ok(opts.extra)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.ok(typeof opts.extra.data === 'string')
   }
@@ -197,7 +232,7 @@ test('server error logging with Object', function (t) {
 
     t.equal(err, 'hapi server emitted a log event tagged error')
     t.ok(opts.extra)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.deepEqual(opts.extra.data, customError)
   }
@@ -227,7 +262,7 @@ test('request error logging with Error', function (t) {
     t.equal(err, customError)
     t.ok(opts.extra)
     t.ok(opts.request)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.ok(opts.extra.data instanceof Error)
   }
@@ -258,6 +293,60 @@ test('request error logging with Error', function (t) {
   })
 })
 
+test('request error logging with Error does not affect event tags', function (t) {
+  t.plan(27)
+
+  var customError = new Error('custom error')
+
+  resetAgent(function (endpoint, headers, data, cb) {
+    assert(t, data, { status: 200, name: 'GET /error' })
+
+    server.stop()
+  })
+
+  agent.captureError = function (err, opts) {
+    t.equal(err, customError)
+    t.ok(opts.extra)
+    t.ok(opts.request)
+    t.deepEqual(opts.extra.tags, ['opbeat', 'error'])
+    t.false(opts.extra.internals)
+    t.ok(opts.extra.data instanceof Error)
+  }
+
+  var server = new Hapi.Server()
+  server.connection()
+
+  server.route({
+    method: 'GET',
+    path: '/error',
+    handler: function (request, reply) {
+      request.log(['opbeat', 'error'], customError)
+
+      return reply('hello world')
+    }
+  })
+
+  server.on('request', function (req, event, tags) {
+      t.deepEqual(event.tags, ['opbeat', 'error']);
+  })
+
+  server.start(function (err) {
+    t.error(err, 'start error')
+
+    server.on('request', function (req, event, tags) {
+        t.deepEqual(event.tags, ['opbeat', 'error']);
+    })
+
+    http.get('http://localhost:' + server.info.port + '/error', function (res) {
+      t.equal(res.statusCode, 200)
+
+      res.resume().on('end', function () {
+        agent._instrumentation._queue._flush()
+      })
+    })
+  })
+})
+
 test('request error logging with String', function (t) {
   t.plan(25)
 
@@ -273,7 +362,7 @@ test('request error logging with String', function (t) {
     t.equal(err, customError)
     t.ok(opts.extra)
     t.ok(opts.request)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.ok(typeof opts.extra.data === 'string')
   }
@@ -321,7 +410,7 @@ test('request error logging with Object', function (t) {
     t.equal(err, 'hapi server emitted a request event tagged error')
     t.ok(opts.extra)
     t.ok(opts.request)
-    t.deepEqual(opts.extra.tags, { error: true })
+    t.deepEqual(opts.extra.tags, ['error'])
     t.false(opts.extra.internals)
     t.deepEqual(opts.extra.data, customError)
   }

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -157,38 +157,38 @@ test('server error logging with Error', function (t) {
 })
 
 test('server error logging with Error does not affect event tags', function (t) {
-    t.plan(8)
+  t.plan(8)
 
-    var customError = new Error('custom error')
+  var customError = new Error('custom error')
 
-    resetAgent()
+  resetAgent()
 
-    agent.captureError = function (err, opts) {
-      server.stop()
+  agent.captureError = function (err, opts) {
+    server.stop()
 
-      t.equal(err, customError)
-      t.ok(opts.extra)
-      t.deepEqual(opts.extra.tags, ['error'])
-      t.false(opts.extra.internals)
-      t.ok(opts.extra.data instanceof Error)
-    }
+    t.equal(err, customError)
+    t.ok(opts.extra)
+    t.deepEqual(opts.extra.tags, ['error'])
+    t.false(opts.extra.internals)
+    t.ok(opts.extra.data instanceof Error)
+  }
 
-    var server = new Hapi.Server()
-    server.connection()
+  var server = new Hapi.Server()
+  server.connection()
+
+  server.on('log', function (event, tags) {
+    t.deepEqual(event.tags, ['error'])
+  })
+
+  server.start(function (err) {
+    t.error(err, 'start error')
 
     server.on('log', function (event, tags) {
-        t.deepEqual(event.tags, ['error']);
+      t.deepEqual(event.tags, ['error'])
     })
 
-    server.start(function (err) {
-      t.error(err, 'start error')
-
-      server.on('log', function (event, tags) {
-          t.deepEqual(event.tags, ['error']);
-      })
-
-      server.log(['error'], customError)
-    })
+    server.log(['error'], customError)
+  })
 })
 
 test('server error logging with String', function (t) {
@@ -327,14 +327,14 @@ test('request error logging with Error does not affect event tags', function (t)
   })
 
   server.on('request', function (req, event, tags) {
-      t.deepEqual(event.tags, ['opbeat', 'error']);
+    t.deepEqual(event.tags, ['opbeat', 'error'])
   })
 
   server.start(function (err) {
     t.error(err, 'start error')
 
     server.on('request', function (req, event, tags) {
-        t.deepEqual(event.tags, ['opbeat', 'error']);
+      t.deepEqual(event.tags, ['opbeat', 'error'])
     })
 
     http.get('http://localhost:' + server.info.port + '/error', function (res) {


### PR DESCRIPTION
This caused bugs (tags being [object Object]) in other log handlers that log to other places. 😱

This change will cause the tags in the extra field in to be 
`tags      ['error', 'email']`
instead of
`tags       {'error': True, 'email': True}`

which seems like an overall improvement 👌