### PR TITLE
Improve GraphQL tracing by including operation name

### DIFF
--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -74,7 +74,7 @@ module.exports = function (graphql, agent, version) {
         if (documentAST) {
           var validationErrors = graphql.validate(schema, documentAST)
           if (validationErrors && validationErrors.length === 0) {
-            var queries = extractQuery(documentAST, operationName)
+            var queries = extractDetails(documentAST, operationName).queries
             if (queries.length > 0) traceName = 'GraphQL: ' + queries.join(', ')
           }
         } else {
@@ -109,13 +109,18 @@ module.exports = function (graphql, agent, version) {
         return orig.apply(this, arguments)
       }
 
-      var queries = extractQuery(document, operationName)
-      if (queries.length > 0) traceName = 'GraphQL: ' + queries.join(', ')
+      var details = extractDetails(document, operationName)
+      var queries = details.queries
+      operationName = operationName || (details.operation && details.operation.name && details.operation.name.value)
+      if (queries.length > 0) traceName = 'GraphQL: ' + (operationName ? operationName + ' ' : '') + queries.join(', ')
 
       if (trans._graphqlRoute) {
         var name = queries.length > 0 ? queries.join(', ') : 'Unknown GraphQL query'
         if (trans.req) var path = express.getPathFromRequest(trans.req)
-        trans.setDefaultName(path ? name + ' (' + path + ')' : name)
+        var defaultName = name
+        defaultName = path ? defaultName + ' (' + path + ')' : defaultName
+        defaultName = operationName ? operationName + ' ' + defaultName : defaultName
+        trans.setDefaultName(defaultName)
       }
 
       trace.start(traceName, 'db.graphql.execute')
@@ -127,7 +132,7 @@ module.exports = function (graphql, agent, version) {
     }
   }
 
-  function extractQuery (document, operationName) {
+  function extractDetails (document, operationName) {
     var queries = []
     var operation
 
@@ -161,6 +166,6 @@ module.exports = function (graphql, agent, version) {
       debug('unexpected document format - skipping graphql query extraction')
     }
 
-    return queries
+    return { queries: queries, operation: operation }
   }
 }


### PR DESCRIPTION
The operation name can often be a critical differentiator between queries, i.e. when used with Relay where you'd often have a `node` query that could be the only root query for various different types of requests throughout an applicaiton.